### PR TITLE
add backup policy to databases

### DIFF
--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -38,5 +38,6 @@ resource "aws_db_instance" "housing-mysql-db" {
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
+    BackupPolicy      = "Prod"
   }
 }

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -19,4 +19,5 @@ module "postgres_db_production" {
   multi_az = true //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
+  tags = { BackupPolicy="Prod"}
 }


### PR DESCRIPTION
## What
-- Add backup policy tag to prod databases

## Why
-- This is to ensure that the databases are included in centralised backups

## Further Information
-- https://docs.google.com/document/d/1aUVOvCMOV9frrmcExMh2pZSGQPOdvNFMbFsNqHUQbWQ/view