### PR TITLE
Backup policy fix

### DIFF
--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -5,7 +5,7 @@ module "postgres_db_development" {
   environment_name = "development"
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"
-  db_engine_version = "12.5"
+  db_engine_version = "12.7"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -5,7 +5,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id =  "vpc-0ce853ddb64e8fb3c"
   db_engine = "postgres"
-  db_engine_version = "12.5"
+  db_engine_version = "12.7"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.large"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -19,5 +19,4 @@ module "postgres_db_production" {
   multi_az = true //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
-  tags = { BackupPolicy="Prod"}
 }


### PR DESCRIPTION
## What
- Fix to tha backup policy terraform config that is causing the deployment to fail.

## Why
- The syntax of the terraform config for adding tags is incorrect for the referenced postres module