### PR TITLE
Add sqlserver db

### DIFF
--- a/development/main.tf
+++ b/development/main.tf
@@ -31,6 +31,15 @@ data "aws_ssm_parameter" "housing_finance_postgres_username" {
 data "aws_ssm_parameter" "housing_finance_postgres_password" {
   name = "/housing-finance/development/postgres-password"
 }
+data "aws_ssm_parameter" "housing_finance_mssql_database" {
+  name = "/housing-finance/development/mssql-database"
+}
+data "aws_ssm_parameter" "housing_finance_mssql_username" {
+  name = "/housing-finance/development/mssql-username"
+}
+data "aws_ssm_parameter" "housing_finance_mssql_password" {
+  name = "/housing-finance/development/mssql-password"
+}
 
 resource "aws_security_group" "mtfh_finance_security_group" {
   name        = "mtfh-finance-allow-traffic-${var.environment_name}"

--- a/production/main.tf
+++ b/production/main.tf
@@ -41,6 +41,12 @@ data "aws_ssm_parameter" "housing_finance_mysql_username" {
 data "aws_ssm_parameter" "housing_finance_mysql_password" {
   name = "/housing-finance/production/mysql-password"
 }
+data "aws_ssm_parameter" "housing_finance_mssql_username" {
+  name = "/housing-finance/production/mssql-username"
+}
+data "aws_ssm_parameter" "housing_finance_mssql_password" {
+  name = "/housing-finance/production/mssql-password"
+}
 
 resource "aws_security_group" "mtfh_finance_security_group" {
   name        = "mtfh-finance-allowdb-traffic-${var.environment_name}"
@@ -94,6 +100,7 @@ resource "aws_security_group" "mtfh_finance_security_group" {
     protocol         = "tcp"
     cidr_blocks      = ["0.0.0.0/0"]
   }
+
 
   egress {
     from_port        = 0

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -1,0 +1,58 @@
+# MS SQL Server DB Setup (no common resource)
+resource "aws_db_subnet_group" "mssql_db_subnets" {
+  name       = "housing-finance-mssql-db-subnet-${var.environment_name}"
+  subnet_ids = ["subnet-0beb266003a56ca82","subnet-06a697d86a9b6ed01"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_instance" "mssql" {
+  allocated_storage    = 30
+  engine               = "sqlserver-ee"
+  engine_version       = "15.00.4198.2.v1"
+  instance_class       = "db.t3.xlarge"
+  license_model        = "license-included"
+  identifier           = "housing-finance-sql-db-${var.environment_name}"
+  username             = data.aws_ssm_parameter.housing_finance_mssql_username.value
+  password             = data.aws_ssm_parameter.housing_finance_mssql_password.value
+  vpc_security_group_ids      = [aws_security_group.mtfh_finance_security_group.id]
+  db_subnet_group_name = aws_db_subnet_group.mssql_db_subnets.name
+  multi_az             = true
+  publicly_accessible  = false
+  backup_retention_period = 30
+  storage_encrypted    = true
+  deletion_protection  = true
+  apply_immediately    = false
+
+  tags = {
+    Name              = "housing-finance-db-${var.environment_name}"
+    Environment       = "${var.environment_name}"
+    terraform-managed = true
+    project_name      = "MTFH Finance"
+  }
+}
+
+resource "aws_db_instance" "mssql-replica" {
+  allocated_storage    = 30
+  engine               = "sqlserver-ee"
+  engine_version       = "15.00.4198.2.v1"
+  instance_class       = "db.t3.xlarge"
+  license_model        = "license-included"
+  identifier           = "housing-finance-sql-db-${var.environment_name}-replica"
+  replicate_source_db  = aws_db_instance.mssql.id
+  vpc_security_group_ids      = [aws_security_group.mtfh_finance_security_group.id]
+  db_subnet_group_name = aws_db_subnet_group.mssql_db_subnets.name
+  multi_az              = false
+  publicly_accessible    = false
+  backup_retention_period = 2
+
+  apply_immediately = "true"
+
+  tags = {
+    Name              = "housing-finance-db-${var.environment_name}"
+    Environment       = "${var.environment_name}"
+    terraform-managed = true
+    project_name      = "MTFH Finance"
+  }
+}

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -5,7 +5,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id =  "vpc-0ce853ddb64e8fb3c"
   db_engine = "postgres"
-  db_engine_version = "12.5"
+  db_engine_version = "12.8"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.large"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value
@@ -19,5 +19,4 @@ module "postgres_db_production" {
   multi_az = true //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
-  tags = { BackupPolicy="Prod"}
 }

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -41,6 +41,12 @@ data "aws_ssm_parameter" "housing_finance_mysql_username" {
 data "aws_ssm_parameter" "housing_finance_mysql_password" {
   name = "/housing-finance/staging/mysql-password"
 }
+data "aws_ssm_parameter" "housing_finance_mssql_username" {
+  name = "/housing-finance/staging/mssql-username"
+}
+data "aws_ssm_parameter" "housing_finance_mssql_password" {
+  name = "/housing-finance/staging/mssql-password"
+}
 
 resource "aws_security_group" "mtfh_finance_security_group" {
   name        = "mtfh-finance-allowdb-traffic-${var.environment_name}"

--- a/staging/mssqldb.tf
+++ b/staging/mssqldb.tf
@@ -1,0 +1,57 @@
+# MS SQL Server DB Setup (no common resource)
+resource "aws_db_subnet_group" "mssql_db_subnets" {
+  name       = "housing-finance-mssql-db-subnet-${var.environment_name}"
+  subnet_ids = ["subnet-0ea0020a44b98a2ca","subnet-0743d86e9b362fa38"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_instance" "mssql" {
+  allocated_storage    = 30
+  engine               = "sqlserver-ee"
+  engine_version       = "15.00.4198.2.v1"
+  instance_class       = "db.t3.xlarge"
+  license_model        = "license-included"
+  identifier           = "housing-finance-sql-db-${var.environment_name}"
+  username             = data.aws_ssm_parameter.housing_finance_mssql_username.value
+  password             = data.aws_ssm_parameter.housing_finance_mssql_password.value
+  vpc_security_group_ids      = [aws_security_group.mtfh_finance_security_group.id]
+  db_subnet_group_name = aws_db_subnet_group.mssql_db_subnets.name
+  multi_az              = false
+  publicly_accessible    = false
+  backup_retention_period = 2
+  skip_final_snapshot = true
+  apply_immediately = true
+
+  tags = {
+    Name              = "housing-finance-db-${var.environment_name}"
+    Environment       = "${var.environment_name}"
+    terraform-managed = true
+    project_name      = "MTFH Finance"
+  }
+}
+
+resource "aws_db_instance" "mssql-replica" {
+  allocated_storage    = 30
+  engine               = "sqlserver-ee"
+  engine_version       = "15.00.4198.2.v1"
+  instance_class       = "db.t3.xlarge"
+  license_model        = "license-included"
+  identifier           = "housing-finance-sql-db-${var.environment_name}-replica"
+  replicate_source_db  = aws_db_instance.mssql.id
+  vpc_security_group_ids      = [aws_security_group.mtfh_finance_security_group.id]
+  db_subnet_group_name = aws_db_subnet_group.mssql_db_subnets.name
+  multi_az              = false
+  publicly_accessible    = false
+  backup_retention_period = 2
+
+  apply_immediately = "true"
+
+  tags = {
+    Name              = "housing-finance-db-${var.environment_name}"
+    Environment       = "${var.environment_name}"
+    terraform-managed = true
+    project_name      = "MTFH Finance"
+  }
+}


### PR DESCRIPTION
## What
Adds SQL Server database and replica instances

## Why
This is required to enable setup of data extract for RentSense

## Notes
Post setup, migration will need to be configured to get data from the existing instance to the new.