### PR TITLE
Tool for automating a Google Service Account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /production/.terraform
 /staging/.terraform.lock.hcl
 /production/.terraform.lock.hcl
+credentials.*
+*.json
+config.py

--- a/maintenance/scripts/google_service_account_automation/DriveServiceAccountClient.py
+++ b/maintenance/scripts/google_service_account_automation/DriveServiceAccountClient.py
@@ -1,0 +1,167 @@
+import json
+import re
+
+from googleapiclient import errors
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from google.oauth2 import service_account
+from config import CREDENTIALS_PATH
+
+class DriveServiceAccountClient:
+    """
+    To use, you must get the credentials JSON string e.g. from Parameter Store, save in the same directory as credentials.json
+    Ensure that you save your credentials as exactly "credentials.json" to have them be gitignored
+    """
+
+    def __init__(self):
+        credentials_filename = CREDENTIALS_PATH
+        self.service_readonly = self._service_from_scopes(credentials_filename, ['https://www.googleapis.com/auth/drive.metadata.readonly'])
+        self.service_read_write = self._service_from_scopes(credentials_filename, ['https://www.googleapis.com/auth/drive'])
+        self.output_filename = "output.json"
+
+    @staticmethod
+    def _service_from_scopes(credentials_filename: str, scopes: list[str]):
+        creds = service_account.Credentials.from_service_account_file(credentials_filename, scopes=scopes)
+        service = build('drive', 'v3', credentials=creds)
+        return service
+
+    def write_data_to_json(self, data: dict):
+        """
+        Writes JSON data to a local file
+        :param data: JSON data / dict to write to file
+        :param filename: Name or path of file to write output to
+        """
+        with open(self.output_filename, "w") as outfile:
+            json.dump(data, outfile)
+            print(f"Data written to {self.output_filename}")
+
+    def get_file_or_folder(self, file_id, fields=None) -> dict:
+        """
+        Gets a file or folder by File ID or Folder ID
+        See: https://developers.google.com/drive/api/v3/reference/files/get
+        :param file_id: ID of file/folder to fetch
+        :param fields: Data about the file/folder to fetch, See https://developers.google.com/drive/api/guides/fields-parameter
+        :return: File response JSON object
+        """
+        try:
+            response = self.service_readonly.files().get(
+                fileId=file_id, fields=fields
+            ).execute()
+            return response
+        except errors.HttpError:
+            print(f"File with id {file_id} not found!")
+
+    def query_files(self, query_lines: list[str]) -> list[str]:
+        """
+        Gets a list of files based on a valid query
+        See https://developers.google.com/drive/api/guides/search-files for valid queries reference
+        :param query_lines: A list of queries following Google's file search query syntax
+        :return: List of files
+        """
+        query = " and ".join(query_lines)
+        print(query)
+        all_results = []
+        page_token = None
+        while True:
+            response = self.service_readonly.files().list(
+                q=query,
+                corpora="allDrives",
+                includeItemsFromAllDrives=True,
+                supportsAllDrives=True,
+                pageToken=page_token,
+                fields="files(id, name, size)"
+            )
+            try:
+                result = response.execute()
+                all_results += result.get("files")
+                page_token = result.get('nextPageToken', None)
+                if page_token is None:
+                    break
+            except errors.HttpError:
+                # When nothing is found, response.execute() throws HttpError
+                pass
+        print(f"{len(all_results)} files found:")
+
+        print(all_results)
+        return all_results
+
+    def upload(self, filename: str, mimetype: str, folder_id: str = None) -> str:
+        """
+        Uploads a local file to Google Drive
+        See https://developers.google.com/drive/api/guides/folder#create_a_file_in_a_folder
+        :param filename: Local file path to open for upload
+        :param mimetype: Example: "text/csv" Consult https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+        :param folder_id: Google ID of folder to upload to. If None, will upload to the root directory.
+        :return:
+        """
+
+        file_metadata = {'name': filename}
+        if folder_id:
+            file_metadata["parent"] = folder_id
+
+        try:
+            media = MediaFileUpload(filename, mimetype=mimetype)
+            file = self.service_read_write.files().create(body=file_metadata, media_body=media, fields='id').execute()
+            print(F'File ID: {file.get("id")}')
+            return file.get('id')
+        except errors.HttpError as error:
+            print(F'An error occurred: {error}')
+            return
+
+    def get_file_parent_folder(self, file_id: str) -> str:
+        """
+        Finds the Google ID of the folder that a file is within
+        :param file_id: ID of the file
+        :return: Parent Folder ID
+        """
+        # I think you can query any attributes from here:
+        # https://developers.google.com/drive/api/v2/reference/files
+        response = self.get_file_or_folder(file_id, fields="parents")
+        return response
+
+    def delete_file(self, file_id: dict):
+        """
+        Permanently delete a file, skipping the trash.
+        See: https://developers.google.com/drive/api/v3/reference/files/delete
+        :param file_id: Google ID of the file to delete
+        """
+        try:
+            self.service_read_write.files().delete(file_id).execute()
+            print(f"Deleted: {file_id}")
+        except errors.HttpError as error:
+            f'An error occurred deleting {file_id}:\n>>> {error}'
+
+    def delete_matching_files_in_folder(self, folder_id, query_lines: list[str] = None, file_regex=None, file_size_minimum: int = 0):
+        """
+        Deletes all files matching a specific query as in query_files, uses filename regex and file_size_minimum as safeguards
+        :param folder_id: ID of folder to find files under
+        :param query_lines: List of filters for files, see https://developers.google.com/drive/api/guides/search-files
+        :param file_regex: Regex the file names must match
+        :param file_size_minimum: Minimum file size
+        """
+
+        # Get files matching queries
+        query_lines = [] if query_lines is None else query_lines
+        folder_parent_query_line = f"'{folder_id}' in parents"
+        if folder_parent_query_line not in query_lines:
+            query_lines.append(f"'{folder_id}' in parents")
+
+        files = self.query_files(query_lines)
+        self.write_data_to_json(files)
+
+        # Get user confirmation for deletion
+        confirmation = input(f"Will delete {len(files)} files in {folder_id}, example: {files[0]}, see {self.output_filename} for all files\nContinue? Y/Yes or N/No")
+        if confirmation.lower() not in ["y", "yes"]:
+            print("Aborting")
+            return
+
+        # Delete all captured files
+        for file in files:
+            if int(file["size"]) > file_size_minimum:
+                if file_regex is not None:
+                    if re.match(file_regex, file["name"]):
+                        print(f"file['name'] DELETING - ", f"{round(int(file['size']) / 10 ** 6, 2)}MB")
+                        self.delete_file(file)
+                else:
+                    print(f"file['name'] DELETING - ", f"{round(int(file['size']) / 10 ** 6, 2)}MB")
+                    self.delete_file(file)

--- a/maintenance/scripts/google_service_account_automation/README.md
+++ b/maintenance/scripts/google_service_account_automation/README.md
@@ -5,7 +5,7 @@ This tool is designed to assist with controlling a Google service account in Goo
 1) Ensure you have a recent version of Python 3 installed as well as the Pip package manager
 2) Create a venv or similar as needed e.g. with `python3 -m venv venv`
 3) Activate the environment e.g. with `source venv/bin/activate` (Linux/Mac) or `\env\Scripts\activate.bat` (Windows)
-4) Run `pip install -r requirements.txt` to install dependencies within the venv
+4) Run `python -m pip install -r requirements.txt` to install dependencies within the venv
 5) Go to e.g. Parameter Store to get the Service Account credentials, and save them in a file named `credentials.json` (gitignored) in the project root directory
 6) Copy `config_sample.py` and rename to `config.py`
 7) Modify the dictionaries in `config.py` (gitignored) to have the file IDs of any files or folders you want to work with

--- a/maintenance/scripts/google_service_account_automation/README.md
+++ b/maintenance/scripts/google_service_account_automation/README.md
@@ -1,0 +1,55 @@
+# Google Account Client
+This tool is designed to assist with controlling a Google service account in Google Drive.
+
+## Setup
+1) Ensure you have a recent version of Python 3 installed as well as the Pip package manager
+2) Create a venv or similar as needed e.g. with `python3 -m venv venv`
+3) Activate the environment e.g. with `source venv/bin/activate` (Linux/Mac) or `\env\Scripts\activate.bat` (Windows)
+4) Run `pip install -r requirements.txt` to install dependencies within the venv
+5) Go to e.g. Parameter Store to get the Service Account credentials, and save them in a file named `credentials.json` (gitignored) in the project root directory
+6) Copy `config_sample.py` and rename to `config.py`
+7) Modify the dictionaries in `config.py` (gitignored) to have the file IDs of any files or folders you want to work with
+
+## Use
+1) Open `main.py`
+2) Use the `service_account` instance's methods inside the `if __name__ == "__main__":` clause
+
+## Note
+See `data_samples` for relevant data schemas.
+
+## Examples
+Get CSV files in a folder in the config named "Project Files" which aren't in the trash and have a name containing "2022", then write these to a json file
+```python
+if __name__ == "__main__": 
+    folder_id = FOLDERS["Project Files"]
+    query_lines = [
+        f"'{folder_id}' in parents",
+        "trashed=false",
+        "mimeType = 'text/csv'",
+        f"name contains '2022'",
+    ]
+
+    files = service_account.query_files(query_lines)
+    service_account.write_data_to_json(files)
+```
+
+___
+
+Uploads a CSV file in the current directory named "test.csv" to the same parent folder of a file defined in `config.py` `FILES`
+
+You could also specify the path to the file under the `filename` like `./files_to_upload/test.csv`
+```python
+if __name__ == "__main__":
+    parent_directory = service_account.get_file_parent_folder(FILES["My Test File"])
+    service_account.upload(filename="test.csv", mimetype="text/csv", folder_id=parent_directory)
+```
+
+___
+
+Deletes all files in a folder stored in Config FOLDERS under key "Folder To Clean" which match the regex (Start with BadFile, have csv in name) and which are greater than 1000000 bytes (1GB) in size
+
+This will ask for user confirmation
+```python
+if __name__ == "__main__":
+    delete_matching_files_in_folder(FOLDERS["Folder To Clean"], file_regex="^BadFile.*csv", file_size_minimum=1000000)
+```

--- a/maintenance/scripts/google_service_account_automation/config_sample.py
+++ b/maintenance/scripts/google_service_account_automation/config_sample.py
@@ -1,0 +1,16 @@
+# This file is a SAMPLE - make a copy and rename it to config.py before editing values
+
+# Path for credentials file
+CREDENTIALS_PATH = "./credentials.json"
+
+"""
+Add folders and files with a memorable identifier as the key and the Google ID (e.g. from the URL) as the value
+Files and folders do not need to have their real names as their identifiers
+"""
+FOLDERS = {
+    "Fake_Folder_Nickname": "FAKE_FOLDER_ID",
+}
+
+FILES = {
+    "Fake_File_Nickname": "FAKE_FILE_ID"
+}

--- a/maintenance/scripts/google_service_account_automation/data_samples/file.py
+++ b/maintenance/scripts/google_service_account_automation/data_samples/file.py
@@ -1,0 +1,6 @@
+file = {
+  "size": "12345",
+  "id": "qwertuiop1234567890",
+  "name": "my_test_csv.csv",
+  "createdTime": "2023-01-12T11:21:20.287Z"
+}

--- a/maintenance/scripts/google_service_account_automation/main.py
+++ b/maintenance/scripts/google_service_account_automation/main.py
@@ -1,0 +1,11 @@
+from DriveServiceAccountClient import DriveServiceAccountClient
+from config import FOLDERS, FILES
+
+service_account = DriveServiceAccountClient()
+
+if __name__ == '__main__':
+    
+    # Replace this and write your code below
+    # Example: Gets a file by its ID defined in the config file
+    file_id = FILES["My Cool File"]
+    file = service_account.get_file_or_folder(file_id)

--- a/maintenance/scripts/google_service_account_automation/requirements.txt
+++ b/maintenance/scripts/google_service_account_automation/requirements.txt
@@ -1,0 +1,2 @@
+google>=3.0.0
+google-api-python-client>=2.78.0


### PR DESCRIPTION
## What
Created a class that can control a Google service account's actions within Google Drive

## Why
Originally was to allow for file cleanup from a location that only this service account had permissions to access and delete from.

Now can generally be used in cases where we need to control the service account directly.

## Notes
Consult the README in the script's directory for usage details