### PR TITLE
Detatch hackney common terraform

### DIFF
--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -18,7 +18,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 
 resource "aws_db_instance" "lbh-db" {
   engine = "postgres"
-  engine_version = "12.14"
+  engine_version = "12.17"
   identifier = "mtfh-finance-pgdb-db-development"
   instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -16,7 +16,7 @@ resource "aws_db_subnet_group" "db_subnets" {
   }
 }
 
-resource "aws_db_instance" "postgres_db_development" {
+resource "aws_db_instance" "lbh-db" {
   engine = "postgres"
   engine_version = "12.14"
   identifier = "mtfh-finance-pgdb-db-development"
@@ -30,7 +30,6 @@ resource "aws_db_instance" "postgres_db_development" {
   maintenance_window ="sun:10:00-sun:10:30"
   storage_encrypted = false
   multi_az = false //only true if production deployment
-  publicly_accessible = false
 
   storage_type                = "gp2" //ssd
   backup_window               = "00:01-00:31"
@@ -42,6 +41,7 @@ resource "aws_db_instance" "postgres_db_development" {
 
   apply_immediately   = false
   skip_final_snapshot = true
+  publicly_accessible = false
 
   tags = {
     Name              = "${data.aws_ssm_parameter.housing_finance_postgres_database.value}-db-development"

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -17,16 +17,14 @@ resource "aws_db_subnet_group" "db_subnets" {
 }
 
 resource "aws_db_instance" "postgres_db_development" {
-  environment_name = "development"
-  vpc_id =  "vpc-0d15f152935c8716f"
-  db_engine = "postgres"
-  db_engine_version = "12.14"
-  db_identifier = "mtfh-finance-pgdb"
-  db_instance_class = "db.t3.micro"
+  engine = "postgres"
+  engine_version = "12.14"
+  identifier = "mtfh-finance-pgdb-db-development"
+  instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value
-  db_port  = data.aws_ssm_parameter.housing_finance_postgres_port.value
-  db_username = data.aws_ssm_parameter.housing_finance_postgres_username.value
-  db_password = data.aws_ssm_parameter.housing_finance_postgres_password.value
+  port  = data.aws_ssm_parameter.housing_finance_postgres_port.value
+  username = data.aws_ssm_parameter.housing_finance_postgres_username.value
+  password = data.aws_ssm_parameter.housing_finance_postgres_password.value
   db_subnet_group_name = aws_db_subnet_group.db_subnets.name
   allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -18,4 +18,23 @@ module "postgres_db_development" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
+
+  storage_type                = "gp2" //ssd
+  backup_window               = "00:01-00:31"
+  monitoring_interval         = 0 //this is for enhanced Monitoring there will allready be some basic monitering avalable
+  backup_retention_period     = 30
+  storage_encrypted           = true
+  deletion_protection         = false
+  auto_minor_version_upgrade  = true
+  allow_major_version_upgrade = false
+
+  apply_immediately   = false
+  skip_final_snapshot = true
+
+  tags = {
+    Name              = "${data.aws_ssm_parameter.housing_finance_postgres_database.value}-db-development"
+    Environment       = "development"
+    terraform-managed = true
+    project_name      = var.project_name
+  }
 }

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -34,6 +34,6 @@ resource "aws_db_instance" "postgres_db_development" {
     Name              = "${data.aws_ssm_parameter.housing_finance_postgres_database.value}-db-development"
     Environment       = "development"
     terraform-managed = true
-    project_name      = var.project_name
+    project_name      = "housing finance"
   }
 }

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -23,7 +23,6 @@ module "postgres_db_development" {
   backup_window               = "00:01-00:31"
   monitoring_interval         = 0 //this is for enhanced Monitoring there will allready be some basic monitering avalable
   backup_retention_period     = 30
-  storage_encrypted           = true
   deletion_protection         = false
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -1,6 +1,6 @@
 # Postg Database Setup
 
-module "postgres_db_development" {
+resource "aws_db_instance" "postgres_db_development" {
   environment_name = "development"
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "lbh-db" {
   db_subnet_group_name = aws_db_subnet_group.db_subnets.name
   allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
+  storage_encrypted = true
   multi_az = false //only true if production deployment
 
   storage_type                = "gp2" //ssd

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -1,7 +1,6 @@
 # Postg Database Setup
 
 module "postgres_db_development" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
   environment_name = "development"
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -1,8 +1,6 @@
 
 # HFS Postgres Master database
 module "postgres_db_master" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git/modules/database/postgres"
-
   environment_name     = var.environment_name
   db_identifier        = "${var.db_identifier}-master"
   db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -1,7 +1,6 @@
 # Postg Database Setup
 
 module "postgres_db_staging" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
   environment_name = "staging"
   vpc_id =  "vpc-064521a7a4109ba31"
   db_engine = "postgres"


### PR DESCRIPTION
Hackney common terraform uses the "name" attribute which fails in the CI pipeline for the postgres database in the current repo following an update to the correct syntax a few months ago.

```
│ Error: Unsupported argument
│ 
│   on .terraform/modules/postgres_db_master/modules/database/postgres/main.tf line 32, in resource "aws_db_instance" "lbh-db":
│   32:   name                        = var.db_name
│ 
│ An argument named "name" is not expected here.
```

This cannot be updated in Hackney common terraform because it breaks pipelines in other projects.
See https://github.com/LBHackney-IT/aws-hackney-common-terraform/pull/66

This PR only includes the changes to dev/staging so that this can be tested