### PR TITLE
Remove EE edition & Add new Web edition DB.

### DIFF
--- a/staging/mssqldb.tf
+++ b/staging/mssqldb.tf
@@ -19,11 +19,11 @@ resource "aws_db_snapshot" "db1_snapshot" {
 }
 
 # use Snapshot1 to create a database with EE instance
-resource "aws_db_instance" "mssql-ee" {
+resource "aws_db_instance" "hfs-mssql-web" {
   snapshot_identifier = aws_db_snapshot.db1_snapshot.id
 
   allocated_storage       = 50
-  engine                  = "sqlserver-ee"
+  engine                  = "sqlserver-web"
   engine_version          = "15.00.4198.2.v1"
   instance_class          = "db.t3.xlarge"
   license_model           = "license-included"


### PR DESCRIPTION
# What:
An edit to the `SQL Server Enterprise Edition` `staging` database resource definition to change it to `SQL Server Web Edition` .

# Why:
We need to delete the `housing-finance-sql-db-staging` EE database as it has been superseded by the `housing-finance-sql-db-prod-dev-copy`. And we need to move the data, schemas, procedures from the `housing-finance-sql-db-prod-dev-copy` EE into the legacy ` housing-finance-staging` WEB _(contains stale data)_.

One snag is that the WEB edition database is not defined using Terraform. Ideally, it would have been created using Terraform.

The idea behind this PR is that we simply modify the config for the database we want to remove to have a different engine. The expectation is that the Terraform deem this a change big enough that it will delete `housing-finance-sql-db-staging` and will create new WEB edition instance that's managed through Terraform.

# Notes:
- This PR is a test. Other values within this definition may change later.