### PR TITLE
Fix mysql config

### DIFF
--- a/staging/mysqldb.tf
+++ b/staging/mysqldb.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "housing-mysql-db" {
 
 resource "aws_db_instance" "housing-mysql-db-replica" {
   identifier                  = "housing-finance-db-${var.environment_name}-replica"
-  replicate_source_db         = "db-VGYMM6BPKHRNHRDUBSIQU4ZR6M" //aws_db_instance.housing-mysql-db.id
+  replicate_source_db         = aws_db_instance.housing-mysql-db.name
   instance_class              = "db.t2.micro" //this should be a more production appropriate instance in production
   allocated_storage           = 10
   storage_type                = "gp2" //ssd

--- a/staging/mysqldb.tf
+++ b/staging/mysqldb.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "housing-mysql-db" {
 
 resource "aws_db_instance" "housing-mysql-db-replica" {
   identifier                  = "housing-finance-db-${var.environment_name}-replica"
-  replicate_source_db         = aws_db_instance.housing-mysql-db.id
+  replicate_source_db         = "db-VGYMM6BPKHRNHRDUBSIQU4ZR6M" //aws_db_instance.housing-mysql-db.id
   instance_class              = "db.t2.micro" //this should be a more production appropriate instance in production
   allocated_storage           = 10
   storage_type                = "gp2" //ssd

--- a/staging/mysqldb.tf
+++ b/staging/mysqldb.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "housing-mysql-db" {
 
 resource "aws_db_instance" "housing-mysql-db-replica" {
   identifier                  = "housing-finance-db-${var.environment_name}-replica"
-  replicate_source_db         = aws_db_instance.housing-mysql-db.name
+  replicate_source_db         = aws_db_instance.housing-mysql-db.identifier
   instance_class              = "db.t2.micro" //this should be a more production appropriate instance in production
   allocated_storage           = 10
   storage_type                = "gp2" //ssd


### PR DESCRIPTION
Fix the config by setting the `id` attribute to `identifier`

### Pipeline logs:

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:
```json
  # aws_db_instance.housing-mysql-db-replica will be updated in-place
  ~ resource "aws_db_instance" "housing-mysql-db-replica" {
        id                                    = "db-5G76C4G4Q5YSYAJOOID4LFUMX4"
      ~ replicate_source_db                   = "housing-finance-db-staging" -> "db-VGYMM6BPKHRNHRDUBSIQU4ZR6M"
        tags                                  = {
            "Environment"       = "staging"
            "Name"              = "housing-finance-db-staging-replica"
            "project_name"      = "MTFH Finance"
            "terraform-managed" = "true"
        }
        # (53 unchanged attributes hidden)
    }
```
╷
│ Error: cannot elect new source database for replication
│ 
│   with aws_db_instance.housing-mysql-db-replica,
│   on mysqldb.tf line 44, in resource "aws_db_instance" "housing-mysql-db-replica":
│   44: resource "aws_db_instance" "housing-mysql-db-replica" {