### PR TITLE
Re-align Terraform with AWS State (Fix Pipeline)

### DIFF
--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -15,6 +15,7 @@ module "postgres_db_development" {
   subnet_ids = ["subnet-05ce390ba88c42bfd","subnet-0140d06fb84fdb547"]
   db_allocated_storage = 20
   maintenance_window ="sun:10:00-sun:10:30"
+  backup_window = "00:01-00:31"
   storage_encrypted = false
   multi_az = false //only true if production deployment
   publicly_accessible = false

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -19,4 +19,5 @@ module "postgres_db_development" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
+  vpc_security_group_ids = [module.db_security_group.security_group_id]
 }

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -18,6 +18,7 @@ module "postgres_db_development" {
   backup_window = "00:01-00:31"
   storage_encrypted = false
   multi_az = false //only true if production deployment
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   publicly_accessible = false
   project_name = "housing finance"
   vpc_security_group_ids = ["sg-0b1844c4c2d5096a2"] // mtfh-finance-allowdb-traffic-production	

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -19,5 +19,5 @@ module "postgres_db_development" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
-  vpc_security_group_ids = [module.db_security_group.security_group_id]
+  vpc_security_group_ids = ["sg-0b1844c4c2d5096a2"] // mtfh-finance-allowdb-traffic-production	
 }

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "lbh-db" {
   storage_type                = "gp2" //ssd
   port                        = var.db_port
   maintenance_window          = var.maintenance_window
-  backup_window               = "08:45-09:15"
+  backup_window               = var.backup_window
   username                    = var.db_username
   password                    = var.db_password
   vpc_security_group_ids      = var.vpc_security_group_ids

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -24,10 +24,10 @@ resource "aws_db_instance" "lbh-db" {
   storage_type                = "gp2" //ssd
   port                        = var.db_port
   maintenance_window          = var.maintenance_window
-  backup_window               = "00:01-00:31"
+  backup_window               = "08:45-09:15"
   username                    = var.db_username
   password                    = var.db_password
-  vpc_security_group_ids      = [module.db_security_group.db_sg_id]
+  vpc_security_group_ids      = ["sg-01396d0029aa1c950", "sg-07d40f16ad18f1f60"]
   db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
   db_name                     = var.db_name
   monitoring_interval         = 0 //this is for enhanced Monitoring there will allready be some basic monitering avalable
@@ -38,6 +38,8 @@ resource "aws_db_instance" "lbh-db" {
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
 
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+
   apply_immediately   = false
   skip_final_snapshot = true
   publicly_accessible = var.publicly_accessible
@@ -47,5 +49,10 @@ resource "aws_db_instance" "lbh-db" {
     Environment       = var.environment_name
     terraform-managed = true
     project_name      = var.project_name
+    BackupPolicy      = var.backup_policy
+  }
+
+  tags_all = {
+    BackupPolicy = var.backup_policy
   }
 }

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -38,7 +38,7 @@ resource "aws_db_instance" "lbh-db" {
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
 
-  enabled_cloudwatch_logs_exports = []
+  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
   apply_immediately   = false
   skip_final_snapshot = true

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -38,7 +38,7 @@ resource "aws_db_instance" "lbh-db" {
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = false
 
-  enabled_cloudwatch_logs_exports = ["postgresql"]
+  enabled_cloudwatch_logs_exports = []
 
   apply_immediately   = false
   skip_final_snapshot = true

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -27,7 +27,7 @@ resource "aws_db_instance" "lbh-db" {
   backup_window               = "08:45-09:15"
   username                    = var.db_username
   password                    = var.db_password
-  vpc_security_group_ids      = ["sg-01396d0029aa1c950", "sg-07d40f16ad18f1f60"]
+  vpc_security_group_ids      = var.vpc_security_group_ids
   db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
   db_name                     = var.db_name
   monitoring_interval         = 0 //this is for enhanced Monitoring there will allready be some basic monitering avalable

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -52,5 +52,5 @@ variable "project_name" {
 
 variable "backup_policy" {
   type = string
-  default = "None"
+  default = null
 }

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -56,3 +56,7 @@ variable "backup_policy" {
 variable "vpc_security_group_ids" {
   type = list(string)
 }
+
+variable "backup_window" {
+  type = string
+}

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -43,6 +43,10 @@ variable "storage_encrypted" {
 variable "multi_az" {
   type = string
 }
+variable "enabled_cloudwatch_logs_exports" {
+  type = list(string)
+  default = []
+}
 variable "publicly_accessible" {
   type = string
 }

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -49,8 +49,10 @@ variable "publicly_accessible" {
 variable "project_name" {
   type = string
 }
-
 variable "backup_policy" {
   type = string
   default = null
+}
+variable "vpc_security_group_ids" {
+  type = list(string)
 }

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -49,3 +49,8 @@ variable "publicly_accessible" {
 variable "project_name" {
   type = string
 }
+
+variable "backup_policy" {
+  type = string
+  default = "None"
+}

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -108,32 +108,3 @@ resource "aws_db_instance" "postgres-replica-03" {
     ]
   }
 }
-
-# Replica 04 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-04" {
-  identifier          = "${var.db_identifier}-replica-db-04-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.large"
-
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-04-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-    BackupPolicy      = "Prod"
-  }
-
-  tags_all = {
-    BackupPolicy = "Prod"
-  }
-
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -20,6 +20,7 @@ module "postgres_db_master" {
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   backup_policy        = var.backup_policy
+  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
 }
 
 

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -56,13 +56,18 @@ resource "aws_db_instance" "postgres-replica-02" {
   identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
   depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+  instance_class      = "db.t3.large"
 
   tags = {
     Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
     Environment       = var.environment_name
     terraform-managed = true
     project_name      = var.project_name
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy = "Prod"
   }
 
   lifecycle {
@@ -80,13 +85,18 @@ resource "aws_db_instance" "postgres-replica-03" {
   identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
   depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+  instance_class      = "db.t3.large"
 
   tags = {
     Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
     Environment       = var.environment_name
     terraform-managed = true
     project_name      = var.project_name
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy = "Prod"
   }
 
   lifecycle {
@@ -104,13 +114,18 @@ resource "aws_db_instance" "postgres-replica-04" {
   identifier          = "${var.db_identifier}-replica-db-04-${var.environment_name}"
   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
   depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+  instance_class      = "db.t3.large"
 
   tags = {
     Name              = "${var.db_identifier}-replica-db-04-${var.environment_name}"
     Environment       = var.environment_name
     terraform-managed = true
     project_name      = var.project_name
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy = "Prod"
   }
 
   lifecycle {

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -7,7 +7,7 @@ module "postgres_db_master" {
   db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
   db_engine            = var.db_engine
   db_engine_version    = var.db_engine_version
-  db_instance_class    = "db.t3.medium" # check production 
+  db_instance_class    = "db.t3.large" # check production 
   vpc_id               = "vpc-0ce853ddb64e8fb3c"
   db_allocated_storage = 240
   db_port              = var.db_port
@@ -19,6 +19,7 @@ module "postgres_db_master" {
   maintenance_window   = var.maintenance_window
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
+  backup_policy        = var.backup_policy
 }
 
 

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -21,7 +21,7 @@ module "postgres_db_master" {
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   backup_policy        = var.backup_policy
-  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
+  vpc_security_group_ids = ["sg-07d40f16ad18f1f60"]
 }
 
 

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -16,6 +16,7 @@ module "postgres_db_master" {
   db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
   storage_encrypted    = var.storage_encrypted
   multi_az             = var.multi_az
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   maintenance_window   = var.maintenance_window
   backup_window        = "08:45-09:15"
   publicly_accessible  = var.publicly_accessible

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -17,6 +17,7 @@ module "postgres_db_master" {
   storage_encrypted    = var.storage_encrypted
   multi_az             = var.multi_az
   maintenance_window   = var.maintenance_window
+  backup_window        = "00:01-00:31"
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   backup_policy        = var.backup_policy

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -17,7 +17,7 @@ module "postgres_db_master" {
   storage_encrypted    = var.storage_encrypted
   multi_az             = var.multi_az
   maintenance_window   = var.maintenance_window
-  backup_window        = "00:01-00:31"
+  backup_window        = "08:45-09:15"
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   backup_policy        = var.backup_policy

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -27,13 +27,18 @@ resource "aws_db_instance" "postgres-replica-01" {
   identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
   depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+  instance_class      = "db.t3.large"
 
   tags = {
     Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
     Environment       = var.environment_name
     terraform-managed = true
     project_name      = var.project_name
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy = "Prod"
   }
 
   lifecycle {

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -21,7 +21,7 @@ module "postgres_db_master" {
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   backup_policy        = var.backup_policy
-  vpc_security_group_ids = ["sg-07d40f16ad18f1f60"]
+  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
 }
 
 

--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -1,0 +1,119 @@
+# HFS Postgres Master database
+module "postgres_db_master" {
+  source = "../modules/postgres"
+
+  environment_name     = var.environment_name
+  db_identifier        = "${var.db_identifier}-master"
+  db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
+  db_engine            = var.db_engine
+  db_engine_version    = var.db_engine_version
+  db_instance_class    = "db.t3.medium" # check production 
+  vpc_id               = "vpc-0ce853ddb64e8fb3c"
+  db_allocated_storage = 240
+  db_port              = var.db_port
+  subnet_ids           = var.subnet_ids
+  db_username          = data.aws_ssm_parameter.hfs_master_postgres_username.value
+  db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
+  storage_encrypted    = var.storage_encrypted
+  multi_az             = var.multi_az
+  maintenance_window   = var.maintenance_window
+  publicly_accessible  = var.publicly_accessible
+  project_name         = var.project_name
+}
+
+
+# Replica 01 :: Accounts Information DB
+resource "aws_db_instance" "postgres-replica-01" {
+  identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+  depends_on          = [module.postgres_db_master.instance_id]
+  instance_class      = "db.t3.medium"
+
+  tags = {
+    Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      storage_encrypted,
+      allocated_storage,
+      deletion_protection
+    ]
+  }
+}
+
+# Replica 02 :: Accounts Information DB
+resource "aws_db_instance" "postgres-replica-02" {
+  identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+  depends_on          = [module.postgres_db_master.instance_id]
+  instance_class      = "db.t3.medium"
+
+  tags = {
+    Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      storage_encrypted,
+      allocated_storage,
+      deletion_protection
+    ]
+  }
+}
+
+# Replica 03 :: Charges DB
+resource "aws_db_instance" "postgres-replica-03" {
+  identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+  depends_on          = [module.postgres_db_master.instance_id]
+  instance_class      = "db.t3.medium"
+
+  tags = {
+    Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      storage_encrypted,
+      allocated_storage,
+      deletion_protection
+    ]
+  }
+}
+
+# Replica 04 :: Accounts Information DB
+resource "aws_db_instance" "postgres-replica-04" {
+  identifier          = "${var.db_identifier}-replica-db-04-${var.environment_name}"
+  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+  depends_on          = [module.postgres_db_master.instance_id]
+  instance_class      = "db.t3.medium"
+
+  tags = {
+    Name              = "${var.db_identifier}-replica-db-04-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      storage_encrypted,
+      allocated_storage,
+      deletion_protection
+    ]
+  }
+}

--- a/production/main.tf
+++ b/production/main.tf
@@ -95,7 +95,7 @@ resource "aws_security_group" "mtfh_finance_security_group" {
     cidr_blocks      = ["0.0.0.0/0"]
   }
 
-    ingress {
+  ingress {
     description      = "Allow traffic for income api"
     from_port        = 3000
     to_port          = 3000
@@ -103,7 +103,7 @@ resource "aws_security_group" "mtfh_finance_security_group" {
     cidr_blocks      = ["0.0.0.0/0"]
   }
 
-    ingress {
+  ingress {
     description      = "Allow traffic for manage arrears front end"
     from_port        = 3001
     to_port          = 3001
@@ -111,7 +111,18 @@ resource "aws_security_group" "mtfh_finance_security_group" {
     cidr_blocks      = ["0.0.0.0/0"]
   }
 
-
+  ingress {
+    description      = "Allow Postgres"
+    from_port        = 5432
+    to_port          = 5432
+    protocol         = "tcp"
+    security_groups  = []
+    self             = false
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = []
+    prefix_list_ids  = []
+  }
+  
   egress {
     from_port        = 0
     to_port          = 0

--- a/production/main.tf
+++ b/production/main.tf
@@ -48,6 +48,16 @@ data "aws_ssm_parameter" "housing_finance_mssql_password" {
   name = "/housing-finance/production/mssql-password"
 }
 
+data "aws_ssm_parameter" "hfs_master_postgres_database" {
+  name = "/housing-finance/staging/hfs-postgres-database"
+}
+data "aws_ssm_parameter" "hfs_master_postgres_username" {
+  name = "/housing-finance/staging/hfs-postgres-username"
+}
+data "aws_ssm_parameter" "hfs_master_postgres_password" {
+  name = "/housing-finance/staging/hfs-postgres-password"
+}
+
 resource "aws_security_group" "mtfh_finance_security_group" {
   name        = "mtfh-finance-allowdb-traffic-${var.environment_name}"
   description = "Allow traffic for the various database types"

--- a/production/main.tf
+++ b/production/main.tf
@@ -49,13 +49,13 @@ data "aws_ssm_parameter" "housing_finance_mssql_password" {
 }
 
 data "aws_ssm_parameter" "hfs_master_postgres_database" {
-  name = "/housing-finance/staging/hfs-postgres-database"
+  name = "/housing-finance/production/hfs-postgres-database"
 }
 data "aws_ssm_parameter" "hfs_master_postgres_username" {
-  name = "/housing-finance/staging/hfs-postgres-username"
+  name = "/housing-finance/production/hfs-postgres-username"
 }
 data "aws_ssm_parameter" "hfs_master_postgres_password" {
-  name = "/housing-finance/staging/hfs-postgres-password"
+  name = "/housing-finance/production/hfs-postgres-password"
 }
 
 resource "aws_security_group" "mtfh_finance_security_group" {

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -14,7 +14,7 @@ data "aws_db_instance" "source_db" {
 
 # Snapshot1 - create a snapshot of the Source DB
 data "aws_db_snapshot" "db1_snapshot" {
-  # db_instance_identifier = data.aws_db_instance.source_db.id
+  db_instance_identifier = data.aws_db_instance.source_db.id
   db_snapshot_identifier = "arn:aws:rds:eu-west-2:282997303675:snapshot:housing-finance-sql-prod-web-snapshot"
 }
 

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -8,14 +8,14 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 }
 
 # identifier for the Source database
-data "aws_db_instance" "source_db" {
-  db_instance_identifier = "${var.mssql-db-source}-${var.environment_name}-web"
-}
+# data "aws_db_instance" "source_db" {
+#   db_instance_identifier = "${var.mssql-db-source}-${var.environment_name}-web"
+# }
 
 # Snapshot1 - create a snapshot of the Source DB
-resource "aws_db_snapshot" "db1_snapshot" {
-  db_instance_identifier = data.aws_db_instance.source_db.id
-  db_snapshot_identifier = "${var.mssql-db-target}-snapshot"
+data "aws_db_snapshot" "db1_snapshot" {
+  # db_instance_identifier = data.aws_db_instance.source_db.id
+  db_snapshot_identifier = "arn:aws:rds:eu-west-2:282997303675:snapshot:housing-finance-sql-prod-web-snapshot"
 }
 
 # use Snapshot1 to create a database with EE instance

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -8,9 +8,9 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 }
 
 # identifier for the Source database
-# data "aws_db_instance" "source_db" {
-#   db_instance_identifier = "${var.mssql-db-source}-${var.environment_name}-web"
-# }
+data "aws_db_instance" "source_db" {
+  db_instance_identifier = "housing-finance-sql-db-production"
+}
 
 # Snapshot1 - create a snapshot of the Source DB
 data "aws_db_snapshot" "db1_snapshot" {

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "mssql-ee" {
   publicly_accessible     = false
   backup_retention_period = 30
   storage_encrypted       = true
-  deletion_protection     = false
+  deletion_protection     = true
   apply_immediately       = false
   skip_final_snapshot     = true
 
@@ -48,7 +48,7 @@ resource "aws_db_instance" "mssql-ee" {
   }
 
   lifecycle {
-    prevent_destroy   = true
+    prevent_destroy   = false
     ignore_changes    = [
       storage_encrypted
     ]

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -13,14 +13,14 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 # }
 
 # Snapshot1 - create a snapshot of the Source DB
-data "aws_db_snapshot" "db1_snapshot" {
-  # db_instance_identifier = data.aws_db_instance.source_db.id
-  db_snapshot_identifier = "housing-finance-sql-db-snapshot"
-}
+# data "aws_db_snapshot" "db1_snapshot" {
+#   # db_instance_identifier = data.aws_db_instance.source_db.id
+#   db_snapshot_identifier = "housing-finance-sql-db-snapshot"
+# }
 
 # use Snapshot1 to create a database with EE instance
 resource "aws_db_instance" "mssql-ee" {
-  snapshot_identifier = data.aws_db_snapshot.db1_snapshot.id
+  snapshot_identifier = "housing-finance-sql-db-snapshot"
 
   allocated_storage       = 240
   engine                  = "sqlserver-ee"

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -20,7 +20,7 @@ data "aws_db_snapshot" "db1_snapshot" {
 
 # use Snapshot1 to create a database with EE instance
 resource "aws_db_instance" "mssql-ee" {
-  snapshot_identifier = aws_db_snapshot.db1_snapshot.id
+  snapshot_identifier = data.aws_db_snapshot.db1_snapshot.id
 
   allocated_storage       = 240
   engine                  = "sqlserver-ee"

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -23,6 +23,7 @@ resource "aws_db_instance" "mssql-ee" {
   snapshot_identifier = "housing-finance-sql-db-snapshot"
 
   allocated_storage       = 240
+  max_allocated_storage   = 1200
   engine                  = "sqlserver-ee"
   engine_version          = "15.00.4198.2.v1"
   instance_class          = "db.t3.xlarge"
@@ -45,6 +46,11 @@ resource "aws_db_instance" "mssql-ee" {
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy      = "Prod"
   }
 
   lifecycle {

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 # Snapshot1 - create a snapshot of the Source DB
 data "aws_db_snapshot" "db1_snapshot" {
   # db_instance_identifier = data.aws_db_instance.source_db.id
-  db_snapshot_identifier = "arn:aws:rds:eu-west-2:282997303675:snapshot:housing-finance-sql-prod-web-snapshot"
+  db_snapshot_identifier = "housing-finance-sql-db-snapshot"
 }
 
 # use Snapshot1 to create a database with EE instance

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -8,13 +8,13 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 }
 
 # identifier for the Source database
-data "aws_db_instance" "source_db" {
-  db_instance_identifier = "housing-finance-sql-db-production"
-}
+# data "aws_db_instance" "source_db" {
+#   db_instance_identifier = "housing-finance-sql-db-production"
+# }
 
 # Snapshot1 - create a snapshot of the Source DB
 data "aws_db_snapshot" "db1_snapshot" {
-  db_instance_identifier = data.aws_db_instance.source_db.id
+  # db_instance_identifier = data.aws_db_instance.source_db.id
   db_snapshot_identifier = "arn:aws:rds:eu-west-2:282997303675:snapshot:housing-finance-sql-prod-web-snapshot"
 }
 

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "mssql-ee" {
   }
 
   lifecycle {
-    prevent_destroy   = false
+    prevent_destroy   = true
     ignore_changes    = [
       storage_encrypted
     ]

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "mssql-ee" {
   publicly_accessible     = false
   backup_retention_period = 30
   storage_encrypted       = true
-  deletion_protection     = true
+  deletion_protection     = false
   apply_immediately       = false
   skip_final_snapshot     = true
 

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -64,19 +64,26 @@ resource "aws_db_instance" "mssql-ee" {
 # create a read replica database from the EE instance
 resource "aws_db_instance" "db_ee_replica" {
   allocated_storage   = 45
+  max_allocated_storage = 1200
   instance_class      = "db.t3.xlarge"
+  apply_immediately = false
 
   #name
   identifier          = "${var.mssql-db-target}-${var.environment_name}-replica"
   skip_final_snapshot = true
 
-  replicate_source_db = aws_db_instance.mssql-ee.id
+  replicate_source_db = aws_db_instance.mssql-ee.identifier
 
   tags = {
     Name              = "${var.mssql-db-target}-${var.environment_name}-replica"
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
+    BackupPolicy      = "Prod"
+  }
+
+  tags_all = {
+    BackupPolicy      = "Prod"
   }
 
   lifecycle {

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -7,16 +7,6 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
   }
 }
 
-# identifier for the Source database
-# data "aws_db_instance" "source_db" {
-#   db_instance_identifier = "housing-finance-sql-db-production"
-# }
-
-# Snapshot1 - create a snapshot of the Source DB
-# data "aws_db_snapshot" "db1_snapshot" {
-#   # db_instance_identifier = data.aws_db_instance.source_db.id
-#   db_snapshot_identifier = "housing-finance-sql-db-snapshot"
-# }
 
 # use Snapshot1 to create a database with EE instance
 resource "aws_db_instance" "mssql-ee" {

--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -20,7 +20,7 @@ resource "aws_db_instance" "housing-mysql-db" {
   password                    = data.aws_ssm_parameter.housing_finance_mysql_password.value
   vpc_security_group_ids      = [aws_security_group.mtfh_finance_security_group.id]
   db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
-  db_name                        = data.aws_ssm_parameter.housing_finance_mysql_database.value
+  db_name                     = data.aws_ssm_parameter.housing_finance_mysql_database.value
   monitoring_interval         = 0 //this is for enhanced Monitoring there will already be some basic monitoring available
   backup_retention_period     = 30
   storage_encrypted           = true

--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0.23"
+  engine_version              = "8.0.35"
   instance_class              = "db.t3.medium"
   allocated_storage           = 50
   storage_type                = "gp2"
@@ -44,7 +44,7 @@ resource "aws_db_instance" "housing-mysql-db" {
 
 resource "aws_db_instance" "housing-mysql-db-replica" {
   identifier                  = "housing-finance-db-${var.environment_name}-replica"
-  replicate_source_db         = aws_db_instance.housing-mysql-db.id
+  replicate_source_db         = aws_db_instance.housing-mysql-db.identifier
   instance_class              = "db.t3.medium"
   allocated_storage           = 50
   storage_type                = "gp2"
@@ -68,5 +68,6 @@ resource "aws_db_instance" "housing-mysql-db-replica" {
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
+    BackupPolicy      = "Prod"
   }
 }

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -21,5 +21,5 @@ module "postgres_db_production" {
   publicly_accessible = false
   project_name = "housing finance"
   backup_policy = "Prod"
-  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
+  vpc_security_group_ids = ["sg-07d40f16ad18f1f60"]
 }

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -20,4 +20,5 @@ module "postgres_db_production" {
   publicly_accessible = false
   project_name = "housing finance"
   backup_policy = "Prod"
+  vpc_security_group_ids = [module.db_security_group.security_group_id]
 }

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -15,6 +15,7 @@ module "postgres_db_production" {
   subnet_ids = ["subnet-0beb266003a56ca82","subnet-06a697d86a9b6ed01"]
   db_allocated_storage = 100
   maintenance_window ="sun:10:00-sun:10:30"
+  backup_window = "00:01-00:31"
   storage_encrypted = true
   multi_az = true //only true if production deployment
   publicly_accessible = false

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -5,7 +5,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id =  "vpc-0ce853ddb64e8fb3c"
   db_engine = "postgres"
-  db_engine_version = "12.8"
+  db_engine_version = "12.17"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.large"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value
@@ -19,4 +19,5 @@ module "postgres_db_production" {
   multi_az = true //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
+  backup_policy = "Prod"
 }

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -20,5 +20,5 @@ module "postgres_db_production" {
   publicly_accessible = false
   project_name = "housing finance"
   backup_policy = "Prod"
-  vpc_security_group_ids = [module.db_security_group.security_group_id]
+  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
 }

--- a/production/rediscache.tf
+++ b/production/rediscache.tf
@@ -8,11 +8,11 @@ resource "aws_elasticache_subnet_group" "redis_subnets" {
 
 resource "aws_elasticache_replication_group" "redis_cache" {
   automatic_failover_enabled    = true
-  availability_zones            = ["eu-west-2a", "eu-west-2b"]
+  preferred_cache_cluster_azs   = ["eu-west-2a", "eu-west-2b"]
   replication_group_id          = "redis-finance-${var.environment_name}-1"
-  replication_group_description = "mtfh finance redis group"
+  description = "mtfh finance redis group"
   node_type             = "cache.t3.small"
-  number_cache_clusters = 2
+  num_cache_clusters    = 2
   parameter_group_name  = "default.redis5.0"
   engine_version        = "5.0.6"
   port                  = 6379

--- a/production/rediscache.tf
+++ b/production/rediscache.tf
@@ -8,7 +8,6 @@ resource "aws_elasticache_subnet_group" "redis_subnets" {
 
 resource "aws_elasticache_replication_group" "redis_cache" {
   automatic_failover_enabled    = true
-  preferred_cache_cluster_azs   = ["eu-west-2a", "eu-west-2b"]
   replication_group_id          = "redis-finance-${var.environment_name}-1"
   description = "mtfh finance redis group"
   node_type             = "cache.t3.small"

--- a/production/variables.postgressql.tf
+++ b/production/variables.postgressql.tf
@@ -1,0 +1,40 @@
+variable "db_identifier" {
+  type    = string
+  default = "housing-finance-postgres"
+}
+variable "db_port" {
+  type    = string
+  default = "5432"
+}
+variable "subnet_ids" {
+  type    = list(string)
+  default = ["subnet-06a697d86a9b6ed01", "subnet-0beb266003a56ca82"]
+}
+variable "db_engine" {
+  type    = string
+  default = "postgres"
+}
+variable "db_engine_version" {
+  type    = string
+  default = "14.10"
+}
+variable "maintenance_window" {
+  type    = string 
+  default = "tue:01:00-tue:03:00"
+}
+variable "storage_encrypted" {
+  type    = bool
+  default = true
+}
+variable "multi_az" {
+  type    = bool
+  default = true
+}
+variable "publicly_accessible" {
+  type    = bool
+  default = false
+}
+variable "project_name" {
+  type    = string
+  default = "Housing-Finance PostgresSQL master and read-replica cluster"
+}

--- a/production/variables.postgressql.tf
+++ b/production/variables.postgressql.tf
@@ -38,3 +38,8 @@ variable "project_name" {
   type    = string
   default = "Housing-Finance PostgresSQL master and read-replica cluster"
 }
+
+variable "backup_policy" {
+  type    = string
+  default = "Prod"
+}

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -20,7 +20,7 @@ module "postgres_db_master" {
   maintenance_window   = var.maintenance_window
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
-  vpc_security_group_ids = ["sg-073e2b36118911fc4"]
+  vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]
 }
 
 

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -20,6 +20,7 @@ module "postgres_db_master" {
   maintenance_window   = var.maintenance_window
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
+  vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]
 }
 
 

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -20,7 +20,7 @@ module "postgres_db_master" {
   maintenance_window   = var.maintenance_window
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
-  vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]
+  vpc_security_group_ids = ["sg-073e2b36118911fc4"]
 }
 
 

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -18,6 +18,7 @@ module "postgres_db_master" {
   storage_encrypted    = var.storage_encrypted
   multi_az             = var.multi_az
   maintenance_window   = var.maintenance_window
+  backup_window        = "00:01-00:31"
   publicly_accessible  = var.publicly_accessible
   project_name         = var.project_name
   vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -17,6 +17,7 @@ module "postgres_db_master" {
   db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
   storage_encrypted    = var.storage_encrypted
   multi_az             = var.multi_az
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   maintenance_window   = var.maintenance_window
   backup_window        = "00:01-00:31"
   publicly_accessible  = var.publicly_accessible

--- a/staging/mssqldb.tf
+++ b/staging/mssqldb.tf
@@ -53,32 +53,3 @@ resource "aws_db_instance" "hfs-mssql-web" {
     ]
   }  
 }
-
-# create a read replica database from the EE instance
-# TODO: If this isn't being used, remove it
-#resource "aws_db_instance" "db_ee_replica" {
-#  allocated_storage   = 30
-#  instance_class      = "db.t3.xlarge"
-#
-#  #name
-#  identifier          = "${var.mssql-db-target}-replica-${var.environment_name}"
-#  skip_final_snapshot = true
-#
-#  replicate_source_db = aws_db_instance.mssql-ee.id
-#
-#  tags = {
-#    Name              = "${var.mssql-db-target}-replica-${var.environment_name}"
-#    Environment       = "${var.environment_name}"
-#    terraform-managed = true
-#    project_name      = "MTFH Finance"
-#  }
-#
-#  lifecycle {
-#    prevent_destroy   = true
-#    ignore_changes    = [
-#      storage_encrypted,
-#      allocated_storage,
-#      deletion_protection
-#    ]
-#  } 
-#}

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -19,5 +19,5 @@ module "postgres_db_staging" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
-  vpc_security_group_ids = [module.db_security_group.security_group_id]
+  vpc_security_group_ids = [aws_security_group.mtfh_finance_security_group.id]
 }

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -19,5 +19,5 @@ module "postgres_db_staging" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
-  vpc_security_group_ids = [aws_security_group.mtfh_finance_security_group.id]
+  vpc_security_group_ids = ["sg-073e2b36118911fc4"]
 }

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -19,4 +19,5 @@ module "postgres_db_staging" {
   multi_az = false //only true if production deployment
   publicly_accessible = false
   project_name = "housing finance"
+  vpc_security_group_ids = [module.db_security_group.security_group_id]
 }

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -14,7 +14,8 @@ module "postgres_db_staging" {
   db_password = data.aws_ssm_parameter.housing_finance_postgres_password.value
   subnet_ids = ["subnet-0743d86e9b362fa38","subnet-0ea0020a44b98a2ca"]
   db_allocated_storage = 20
-  maintenance_window ="sat:10:00-sat:10:30"
+  maintenance_window = "sat:10:00-sat:10:30"
+  backup_window = "00:01-00:31"
   storage_encrypted = false
   multi_az = false //only true if production deployment
   publicly_accessible = false


### PR DESCRIPTION
# What
Fix the production terraform to match what is currently deployed and dealt with any subsequent effects on staging and development

# Why
This will allow us to manage finance infrastructure using Terraform going forwards without errors blocking the pipeline

# How
- Viewed `terraform plan` outputs for production to check for changes that would be made
- Reverted any significant changes that would be made in the Terraform in order to eliminate them
- Resolved any subsequent staging and development modifications and edited their config to better represent production

# Notes
- The postgres replicas for finance weren't in the Terraform and had to be added
- Adapted key names to match the new Terraform version requirements
- The Terraform intends to set the db_name for various databases, but this will not affect functionality
- Terraform plan on prod suggests creating an S3 bucket for `civicapay_cashfile_sync` but this already exists on prod and so will not have any effect (tested on dev & staging) - see PR that added the related Terraform: #10 

Prod tf diff (from `terraform plan` on CircleCI)

```terraform
# aws_db_instance.housing-mysql-db will be updated in-place
  ~ resource "aws_db_instance" "housing-mysql-db" {
      # Warning: this attribute value will be marked as sensitive and will not
      # display in UI output after applying this change. The value is unchanged.
      ~ db_name                               = (sensitive value)
        id                                    = "db-B5CNMPPNCQQ4OAXJVNYJH4OYBA"
        tags                                  = {
            "BackupPolicy"      = "Prod"
            "Environment"       = "production"
            "Name"              = "housing-finance-db-production"
            "project_name"      = "MTFH Finance"
            "terraform-managed" = "true"
        }
        # (54 unchanged attributes hidden)
    }

  # module.civicapay_cashfile_sync.aws_s3_object.s3_folder will be created
  + resource "aws_s3_object" "s3_folder" {
      + acl                    = (known after apply)
      + arn                    = (known after apply)
      + bucket                 = "civica-sftp-cashfile-bucket-production"
      + bucket_key_enabled     = (known after apply)
      + checksum_crc32         = (known after apply)
      + checksum_crc32c        = (known after apply)
      + checksum_sha1          = (known after apply)
      + checksum_sha256        = (known after apply)
      + content_type           = "application/octet-stream"
      + etag                   = (known after apply)
      + force_destroy          = false
      + id                     = (known after apply)
      + key                    = "cashfiles/"
      + kms_key_id             = (known after apply)
      + server_side_encryption = (known after apply)
      + storage_class          = (known after apply)
      + tags_all               = (known after apply)
      + version_id             = (known after apply)
    }

  # module.postgres_db_master.aws_db_instance.lbh-db will be updated in-place
  ~ resource "aws_db_instance" "lbh-db" {
      # Warning: this attribute value will be marked as sensitive and will not
      # display in UI output after applying this change. The value is unchanged.
      ~ db_name                               = (sensitive value)
        id                                    = "db-JAGRAFT7FPIM7PMV2CDPYP6UEU"
        tags                                  = {
            "BackupPolicy"      = "Prod"
            "Environment"       = "production"
            "Name"              = (sensitive value)
            "project_name"      = "Housing-Finance PostgresSQL master and read-replica cluster"
            "terraform-managed" = "true"
        }
        # (54 unchanged attributes hidden)
    }

  # module.postgres_db_production.aws_db_instance.lbh-db will be updated in-place
  ~ resource "aws_db_instance" "lbh-db" {
      # Warning: this attribute value will be marked as sensitive and will not
      # display in UI output after applying this change. The value is unchanged.
      ~ db_name                               = (sensitive value)
        id                                    = "db-5GGVRV6IYGPNFGAON5YMVGYWLI"
        tags                                  = {
            "BackupPolicy"      = "Prod"
            "Environment"       = "production"
            "Name"              = (sensitive value)
            "project_name"      = "housing finance"
            "terraform-managed" = "true"
        }
        # (54 unchanged attributes hidden)
    }
```