### PR TITLE
Temporarily remove postgres master until migration

### DIFF
--- a/production/main.postgressql.tf
+++ b/production/main.postgressql.tf
@@ -1,114 +1,119 @@
-# HFS Postgres Master database
-module "postgres_db_master" {
-  source = "../modules/postgres"
+/*
+  This table is intended for creating a Postgres table for migration away from the Enterprise Edition SQL Server database.
+  This should be re-activated when we are ready to begin the migration process.
+*/
 
-  environment_name     = var.environment_name
-  db_identifier        = "${var.db_identifier}-master"
-  db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
-  db_engine            = var.db_engine
-  db_engine_version    = var.db_engine_version
-  db_instance_class    = "db.t3.large" # check production 
-  vpc_id               = "vpc-0ce853ddb64e8fb3c"
-  db_allocated_storage = 240
-  db_port              = var.db_port
-  subnet_ids           = var.subnet_ids
-  db_username          = data.aws_ssm_parameter.hfs_master_postgres_username.value
-  db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
-  storage_encrypted    = var.storage_encrypted
-  multi_az             = var.multi_az
-  enabled_cloudwatch_logs_exports = ["postgresql"]
-  maintenance_window   = var.maintenance_window
-  backup_window        = "08:45-09:15"
-  publicly_accessible  = var.publicly_accessible
-  project_name         = var.project_name
-  backup_policy        = var.backup_policy
-  vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
-}
+# # HFS Postgres Master database
+# module "postgres_db_master" {
+#   source = "../modules/postgres"
+
+#   environment_name     = var.environment_name
+#   db_identifier        = "${var.db_identifier}-master"
+#   db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
+#   db_engine            = var.db_engine
+#   db_engine_version    = var.db_engine_version
+#   db_instance_class    = "db.t3.large" # check production 
+#   vpc_id               = "vpc-0ce853ddb64e8fb3c"
+#   db_allocated_storage = 240
+#   db_port              = var.db_port
+#   subnet_ids           = var.subnet_ids
+#   db_username          = data.aws_ssm_parameter.hfs_master_postgres_username.value
+#   db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
+#   storage_encrypted    = var.storage_encrypted
+#   multi_az             = var.multi_az
+#   enabled_cloudwatch_logs_exports = ["postgresql"]
+#   maintenance_window   = var.maintenance_window
+#   backup_window        = "08:45-09:15"
+#   publicly_accessible  = var.publicly_accessible
+#   project_name         = var.project_name
+#   backup_policy        = var.backup_policy
+#   vpc_security_group_ids = ["sg-07d40f16ad18f1f60", "sg-01396d0029aa1c950"]
+# }
 
 
-# Replica 01 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-01" {
-  identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.large"
+# # Replica 01 :: Accounts Information DB
+# resource "aws_db_instance" "postgres-replica-01" {
+#   identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.large"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-    BackupPolicy      = "Prod"
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#     BackupPolicy      = "Prod"
+#   }
 
-  tags_all = {
-    BackupPolicy = "Prod"
-  }
+#   tags_all = {
+#     BackupPolicy = "Prod"
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }
 
-# Replica 02 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-02" {
-  identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.large"
+# # Replica 02 :: Accounts Information DB
+# resource "aws_db_instance" "postgres-replica-02" {
+#   identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.large"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-    BackupPolicy      = "Prod"
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#     BackupPolicy      = "Prod"
+#   }
 
-  tags_all = {
-    BackupPolicy = "Prod"
-  }
+#   tags_all = {
+#     BackupPolicy = "Prod"
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }
 
-# Replica 03 :: Charges DB
-resource "aws_db_instance" "postgres-replica-03" {
-  identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.large"
+# # Replica 03 :: Charges DB
+# resource "aws_db_instance" "postgres-replica-03" {
+#   identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.large"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-    BackupPolicy      = "Prod"
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#     BackupPolicy      = "Prod"
+#   }
 
-  tags_all = {
-    BackupPolicy = "Prod"
-  }
+#   tags_all = {
+#     BackupPolicy = "Prod"
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }

--- a/staging/main.postgressql.tf
+++ b/staging/main.postgressql.tf
@@ -1,123 +1,127 @@
+/*
+  This table is intended for creating a Postgres table for migration away from the Enterprise Edition SQL Server database.
+  This should be re-activated when we are ready to begin the migration process.
+*/
 
-# HFS Postgres Master database
-module "postgres_db_master" {
-  source = "../modules/postgres"
+# # HFS Postgres Master database
+# module "postgres_db_master" {
+#   source = "../modules/postgres"
 
-  environment_name     = var.environment_name
-  db_identifier        = "${var.db_identifier}-master"
-  db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
-  db_engine            = var.db_engine
-  db_engine_version    = var.db_engine_version
-  db_instance_class    = "db.t3.medium" # check production 
-  vpc_id               = "vpc-064521a7a4109ba31"
-  db_allocated_storage = 50 # production = 240
-  db_port              = var.db_port
-  subnet_ids           = var.subnet_ids
-  db_username          = data.aws_ssm_parameter.hfs_master_postgres_username.value
-  db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
-  storage_encrypted    = var.storage_encrypted
-  multi_az             = var.multi_az
-  enabled_cloudwatch_logs_exports = ["postgresql"]
-  maintenance_window   = var.maintenance_window
-  backup_window        = "00:01-00:31"
-  publicly_accessible  = var.publicly_accessible
-  project_name         = var.project_name
-  vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]
-}
+#   environment_name     = var.environment_name
+#   db_identifier        = "${var.db_identifier}-master"
+#   db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
+#   db_engine            = var.db_engine
+#   db_engine_version    = var.db_engine_version
+#   db_instance_class    = "db.t3.medium" # check production 
+#   vpc_id               = "vpc-064521a7a4109ba31"
+#   db_allocated_storage = 50 # production = 240
+#   db_port              = var.db_port
+#   subnet_ids           = var.subnet_ids
+#   db_username          = data.aws_ssm_parameter.hfs_master_postgres_username.value
+#   db_password          = data.aws_ssm_parameter.hfs_master_postgres_password.value
+#   storage_encrypted    = var.storage_encrypted
+#   multi_az             = var.multi_az
+#   enabled_cloudwatch_logs_exports = ["postgresql"]
+#   maintenance_window   = var.maintenance_window
+#   backup_window        = "00:01-00:31"
+#   publicly_accessible  = var.publicly_accessible
+#   project_name         = var.project_name
+#   vpc_security_group_ids = ["sg-0ce270bb666a7ad64"]
+# }
 
 
-# Replica 01 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-01" {
-  identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+# # Replica 01 :: Accounts Information DB
+# resource "aws_db_instance" "postgres-replica-01" {
+#   identifier          = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.medium"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-01-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }
 
-# Replica 02 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-02" {
-  identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+# # Replica 02 :: Accounts Information DB
+# resource "aws_db_instance" "postgres-replica-02" {
+#   identifier          = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.medium"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-02-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }
 
-# Replica 03 :: Charges DB
-resource "aws_db_instance" "postgres-replica-03" {
-  identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+# # Replica 03 :: Charges DB
+# resource "aws_db_instance" "postgres-replica-03" {
+#   identifier          = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.medium"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-03-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }
 
-# Replica 04 :: Accounts Information DB
-resource "aws_db_instance" "postgres-replica-04" {
-  identifier          = "${var.db_identifier}-replica-db-04-${var.environment_name}"
-  replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
-  depends_on          = [module.postgres_db_master.instance_id]
-  instance_class      = "db.t3.medium"
+# # Replica 04 :: Accounts Information DB
+# resource "aws_db_instance" "postgres-replica-04" {
+#   identifier          = "${var.db_identifier}-replica-db-04-${var.environment_name}"
+#   replicate_source_db = "${var.db_identifier}-master-db-${var.environment_name}"
+#   depends_on          = [module.postgres_db_master.instance_id]
+#   instance_class      = "db.t3.medium"
 
-  tags = {
-    Name              = "${var.db_identifier}-replica-db-04-${var.environment_name}"
-    Environment       = var.environment_name
-    terraform-managed = true
-    project_name      = var.project_name
-  }
+#   tags = {
+#     Name              = "${var.db_identifier}-replica-db-04-${var.environment_name}"
+#     Environment       = var.environment_name
+#     terraform-managed = true
+#     project_name      = var.project_name
+#   }
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      storage_encrypted,
-      allocated_storage,
-      deletion_protection
-    ]
-  }
-}
+#   lifecycle {
+#     prevent_destroy = true
+#     ignore_changes = [
+#       storage_encrypted,
+#       allocated_storage,
+#       deletion_protection
+#     ]
+#   }
+# }


### PR DESCRIPTION
We noticed some costs related to AWS DMS, which is assumed to be related to the read-replicas of the Postgres Master database.

Because we are not yet ready to migrate to this database, this PR comments the related terraform out in order to reduce this cost until we are ready to begin the migration.