### PR TITLE
👥 Update CODEOWNERS to Housing Products team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,2 @@
 # doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHackney-IT/mtfh-developers
+* @LBHackney-IT/housing-products


### PR DESCRIPTION
Following [the agreed ownership doc](https://docs.google.com/spreadsheets/d/1LgO0NIONzxwwHfmddC-Y8JPKbLHRlFqQITKfrIZ5GfU/edit#gid=0) this updates the owners from a deprecated group to belong to Housing Products team.