### PR TITLE
Fix `development` terraform drift for the `Housing-Development` AWS environment.

### DIFF
--- a/civicapay_cashfile_sync_module/Policy-template-S3.tpl
+++ b/civicapay_cashfile_sync_module/Policy-template-S3.tpl
@@ -21,8 +21,8 @@
             },
             "Action": "s3:*",
             "Resource": [
-                "arn:aws:s3:::civica-sftp-cashfile-bucket-production",
-                "arn:aws:s3:::civica-sftp-cashfile-bucket-production/*"
+                "${s3-bucket-arn}",
+                "${s3-bucket-arn}/*"
             ],
             "Condition": {
                 "Bool": {

--- a/development/main.postgressql.tf
+++ b/development/main.postgressql.tf
@@ -14,7 +14,7 @@ module "postgres_db_master" {
   environment_name     = var.environment_name
   db_identifier        = "housing-finance-master"
   db_engine            = "postgres"
-  db_engine_version    = "16.1"
+  db_engine_version    = "16.3"
   db_instance_class    = "db.t3.xlarge"
   db_name              = data.aws_ssm_parameter.hfs_master_postgres_database.value
   # TODO: Replace these with a parameter group

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -6,7 +6,7 @@ module "postgres_db_development" {
   environment_name = "development"
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"
-  db_engine_version = "12.17"
+  db_engine_version = "16.3"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -7,6 +7,7 @@ module "postgres_db_development" {
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"
   db_engine_version = "16.3"
+  db_parameter_group_name = "postgres-16"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.micro"
   db_name = data.aws_ssm_parameter.housing_finance_postgres_database.value

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -19,6 +19,7 @@ resource "aws_db_instance" "lbh-db" {
   identifier                  = "${var.db_identifier}-db-${var.environment_name}"
   engine                      = "postgres"
   engine_version              = var.db_engine_version # Use an appropriate db version for production instances
+  parameter_group_name        = var.db_parameter_group_name
   instance_class              = var.db_instance_class # Use an appropriate instance class for production instances
   allocated_storage           = var.db_allocated_storage
   storage_type                = "gp2" //ssd

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -22,6 +22,11 @@ variable "db_engine" {
 variable "db_engine_version" {
   type = string
 }
+variable "db_parameter_group_name" {
+  description = "Allows attach a specific db parameter group by its name."
+  type = string
+  default = null
+}
 variable "db_instance_class" {
   type = string
 }


### PR DESCRIPTION
# What:
 - Fix the `development` TF drift for Civica S3 Bucket policy's `AllowSSLRequestsOnly` statement target.
 - Fix the `development TF drift for the `mtfh-finance-pgdb` and `housing-finance-master` databases engine versions.
 - Extend the custom postgres instance module to allow specifying custom database parameter group.
 - Attach a custom database parameter group to the `mtfh-finance-pgdb` database as that's what's attached on the actual cloud environment.

# Why:
 - Fixing the terraform drift so that our team's database upgrade work doesn't get undone with the next pipeline run.
 - Fixing the non-database terraform drift not to undo any manually or via scipts applied configuration changes with the subsequent pipeline run.

# Notes:
 - The attached custom parameter group does not force_ssl, which we have found is an issue w/o further configuration. It was agreed that force_ssl=1 will be considered in the future, but not for an immediate upgrade work.
 - The `postgres-16` database parameter group was created manually via AWS console by some of the previous upgrade work this team has done.
 - The password being changed may be shown because the AWS SSM parameter value has been changed due to a credential [[leak](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/156/commits/989e659b00f86eaf57dbe587c80e45e97f99ba1e)] since the terraform was run last time.

```
~ resource "aws_db_instance" "lbh-db" {
        id                                    = "housing-finance-master-db-development"
        name                                  = "housingfinance"
      ~ password                              = (sensitive value)
        tags                                  = {
            "Environment"       = "development"
            "Name"              = (sensitive value)
            "project_name"      = "Housing-Finance PostgreSQL master database"
            "terraform-managed" = "true"
        }
        # (49 unchanged attributes hidden)
    }
```