### PR TITLE
Set HFS MSSQL Enterprise Edition production database maintenance and backup windows to avoid clashing with the nightly run hours.

### DIFF
--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -66,6 +66,8 @@ resource "aws_db_instance" "db_ee_replica" {
 
   replicate_source_db = aws_db_instance.mssql-ee.identifier
 
+  maintenance_window      = "Sun:10:00-Sun:12:00"
+
   tags = {
     Name              = "${var.mssql-db-target}-${var.environment_name}-replica"
     Environment       = "${var.environment_name}"

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -32,6 +32,7 @@ resource "aws_db_instance" "mssql-ee" {
   skip_final_snapshot     = true
 
   maintenance_window      = "Sun:10:00-Sun:12:00"
+  backup_window           = "22:30-23:30"
 
   tags = {
     Name              = "${var.mssql-db-target}-${var.environment_name}"

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -31,6 +31,8 @@ resource "aws_db_instance" "mssql-ee" {
   apply_immediately       = false
   skip_final_snapshot     = true
 
+  maintenance_window      = "Sun:10:00-Sun:12:00"
+
   tags = {
     Name              = "${var.mssql-db-target}-${var.environment_name}"
     Environment       = "${var.environment_name}"


### PR DESCRIPTION
# What:
 - Set HFS master and its replica database maintenance windows to Sunday morning.
 - Set HFS master database backup window to be just before the end of the day.

# Why:
 - The current maintenance window of: `wed:02:09-wed:02:39` conflicts with a resource intense, business-critical nightly run that happens between midnight and ~8'o clock in the morning. Today we had an incident where the nightly run was cancelled amidst charges and transactions calculation due to the database shutting down and going into a maintenance window.
 - Backup window was set to happen before the start of the nightly run so that the backup made doesn't contain partial business-critical nightly run process changes.

# Notes:
 - Backup window could alternatively be set to be after the nightly run has finished, however, it so happens that the last hour of nightly run overlaps with some users having started using the system.
 - The maintenance window was set to sunday morning to ensure there's no overlap with database usage. Morning hours choice is an arbitrary one that's just following a common trend for our databases.