### PR TITLE
Tweak CCI pipeline so live changes are deployed instead of previewed after having been approved.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
   terraform-init-and-apply-to-production:
     executor: docker-terraform
     steps:
-      - terraform-init-then-plan:
+      - terraform-init-then-apply:
           environment: "production"
 
 workflows:


### PR DESCRIPTION
# What:
 - Make live terraform changes deployment use correct CCI command.

# Why:
 - The CCI live infrastructure deployment job was using a changes preview rather than changes release command.

# Notes:
 - At the time that change was introduced, it was intentional. The idea was to resolve some terraform drift before hand, and only then unblock live deployment. The drift has been resolved since, so the deployment restriction via CCI is lifted now.