### PR TITLE
TS-2047 Use default postgres16 parameter group for pre-prod

### DIFF
--- a/pre-production/postgresdb.tf
+++ b/pre-production/postgresdb.tf
@@ -11,7 +11,7 @@ module "postgres_db_pre_production" {
   vpc_id                          = "vpc-062a957b99c8b12e6"
   db_engine                       = "postgres"
   db_engine_version               = "16.3"
-  db_parameter_group_name         = "postgres16"
+  db_parameter_group_name         = "default.postgres16"
   db_identifier                   = "mtfh-finance-pgdb"
   db_instance_class               = "db.t3.micro"
   db_name                         = data.aws_ssm_parameter.housing_finance_postgres_database.value


### PR DESCRIPTION
## What
Use default postgres 16 parameter group for the pre-production database

## Why
Current configuration is invalid due to wrong parameter group name

## Link to ticket (Jira, Trello, Clickup, etc)
[TS-2047](https://hackney.atlassian.net/browse/TS-2047)


[TS-2047]: https://hackney.atlassian.net/browse/TS-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ