### PR TITLE
Enable HFS SQLServer RDS automatic minor version upgrades.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,6 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  assume-role-pre-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
   # Infrastructure changes preview:
   preview-terraform-development-changes:
     executor: docker-terraform
@@ -114,11 +109,6 @@ jobs:
     steps:
       - terraform-init-then-plan:
           environment: "production"
-  preview-terraform-pre-production-changes:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-plan:
-          environment: "pre-production"
   # Infrastructure deployment:
   terraform-init-and-apply-to-development:
     executor: docker-terraform
@@ -135,11 +125,6 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
-  terraform-init-and-apply-to-pre-production:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "pre-production"
 
 workflows:
   preview-staging-and-prod-from-feature-branch:
@@ -163,17 +148,6 @@ workflows:
       - preview-terraform-production-changes:
           requires:
             - assume-role-production
-          filters:
-            branches:
-              ignore: main
-      - assume-role-pre-production:
-          context: api-assume-role-housing-pre-production-context
-          filters:
-            branches:
-              ignore: main
-      - preview-terraform-pre-production-changes:
-          requires:
-            - assume-role-pre-production
           filters:
             branches:
               ignore: main
@@ -253,25 +227,3 @@ workflows:
           filters:
             branches:
               only: main
-
-  terraform-apply-pre-production:
-    jobs:
-      - permit-pre-production-terraform-workflow:
-          type: approval
-          filters:
-            branches:
-              only: main
-      - assume-role-pre-production:
-          context: api-assume-role-housing-pre-production-context
-          requires:
-            - permit-pre-production-terraform-workflow
-      - preview-terraform-pre-production-changes:
-          requires:
-            - assume-role-pre-production
-      - permit-pre-production-terraform-deployment:
-          type: approval
-          requires:
-            - preview-terraform-pre-production-changes
-      - terraform-init-and-apply-to-pre-production:
-          requires:
-            - permit-pre-production-terraform-deployment

--- a/production/mssqldb.tf
+++ b/production/mssqldb.tf
@@ -9,8 +9,8 @@ resource "aws_db_subnet_group" "mssql_db_subnets" {
 
 
 resource "aws_db_instance" "mssql-ee" {
-  allocated_storage       = 2500
-  max_allocated_storage   = 3000
+  allocated_storage       = 1000
+  max_allocated_storage   = 0
   engine                  = "sqlserver-ee"
   engine_version          = "15.00.4198.2.v1"
   instance_class          = "db.t3.xlarge"
@@ -27,8 +27,9 @@ resource "aws_db_instance" "mssql-ee" {
   deletion_protection     = true
   apply_immediately       = false
   skip_final_snapshot     = true
-  performance_insights_enabled = true
+  performance_insights_enabled = false
 
+  copy_tags_to_snapshot       = true
   auto_minor_version_upgrade  = true
   maintenance_window          = "Sun:10:00-Sun:12:00"
   backup_window               = "22:30-23:30"
@@ -38,10 +39,6 @@ resource "aws_db_instance" "mssql-ee" {
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
-    BackupPolicy      = "Prod"
-  }
-
-  tags_all = {
     BackupPolicy      = "Prod"
   }
 
@@ -73,11 +70,7 @@ resource "aws_db_instance" "db_ee_replica" {
     Environment       = "${var.environment_name}"
     terraform-managed = true
     project_name      = "MTFH Finance"
-    BackupPolicy      = "Prod"
-  }
-
-  tags_all = {
-    BackupPolicy      = "Prod"
+    Backup            = false
   }
 
   lifecycle {

--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0.35"
+  engine_version              = "8.0.40"
   instance_class              = "db.t3.medium"
   allocated_storage           = 50
   storage_type                = "gp2"

--- a/staging/mysqldb.tf
+++ b/staging/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0.35"
+  engine_version              = "8.0.40"
   instance_class              = "db.t3.micro" //this should be a more production appropriate instance in production
   allocated_storage           = 10
   storage_type                = "gp2" //ssd


### PR DESCRIPTION
# What:
 - Enabled deletion protection on HFS production SQL Server database.
 - Enabled automatic engine minor version upgrade for HFS production SQL Server RDS instance.
 - Resolved TF drift: #52 .
 - Removed failing Temporary Accomodation pipeline steps: #53 .

# Why:
 - The minor version auto-upgrade was requested by the CE team, I believe, because they need it done for their security scan/review.
 - Enabled deletion protection as it was always on, and only was disabled for some specific piece of work after which it was forgotten to be set back on.
 - For the reasoning behind the rest of the changes refer to the linked PRs.