### PR TITLE
Remove the Pre-Production environment CCI pipeline configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,6 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  assume-role-pre-production:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
   # Infrastructure changes preview:
   preview-terraform-development-changes:
     executor: docker-terraform
@@ -114,11 +109,6 @@ jobs:
     steps:
       - terraform-init-then-plan:
           environment: "production"
-  preview-terraform-pre-production-changes:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-plan:
-          environment: "pre-production"
   # Infrastructure deployment:
   terraform-init-and-apply-to-development:
     executor: docker-terraform
@@ -135,11 +125,6 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
-  terraform-init-and-apply-to-pre-production:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "pre-production"
 
 workflows:
   preview-staging-and-prod-from-feature-branch:


### PR DESCRIPTION
# What:
 - Remove the pre-production Terraform steps from CCI pipeline.

# Why:
- These steps fail with some sort TF lock conflict. It's not worth addressing due to the Temporary Accommodation being on indefinite pause. (likely due to becoming replaced by the off-the-shelf system in the future)

# Notes:
 - This workflow was added as part of PR #48 . If it needs to be reinstated, the entire CCI config can just be copied and pasted onto the latest CCI config version.