### PR TITLE
Remove minor version from mysql terraform

### DIFF
--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0.40"
+  engine_version              = "8.0"
   instance_class              = "db.t3.medium"
   allocated_storage           = 50
   storage_type                = "gp2"

--- a/staging/mysqldb.tf
+++ b/staging/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0.40"
+  engine_version              = "8.0"
   instance_class              = "db.t3.micro" //this should be a more production appropriate instance in production
   allocated_storage           = 10
   storage_type                = "gp2" //ssd


### PR DESCRIPTION
Remove minor version from mysql terraform - AWS is updating these automatically so no point hardcoding them in terraform - our terraform would just keep getting out of sync