### PR TITLE
Postgres terraform drift fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,12 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.9
-  aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  aws_assume_role: lbh-hackit/aws_assume_role@0.1.1
 
 executors:
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.12
   docker-terraform:
     docker:
       - image: "hashicorp/terraform:light"
@@ -107,27 +106,8 @@ jobs:
   preview-terraform-production-changes:
     executor: docker-terraform
     steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: get and init
-          command: |
-            cd ./production/
-            terraform get -update=true
-            terraform init
-      - run:
-          # TODO: Remove after state is fixed
-          name: fix postgres state drift
-          command: |
-            cd ./production/
-            terraform state rm module.postgres_db_production.aws_db_instance.lbh-db || true
-            terraform import module.postgres_db_production.aws_db_instance.lbh-db mtfh-finance-pgdb-db-production
-      - run:
-          # PLEASE LEAVE THIS AS A PLAN, IF YOU WANT TO CHANGE IT THEN SPEAK TO HUMAIRAA FIRST.
-          name: plan
-          command: |
-            cd ./production/
-            terraform plan
+      - terraform-init-then-plan:
+          environment: "production"
   # Infrastructure deployment:
   terraform-init-and-apply-to-development:
     executor: docker-terraform
@@ -187,36 +167,36 @@ workflows:
             - permit-development-terraform-release
   terraform-apply-staging-and-production:
     jobs:
-      # - assume-role-staging:
-      #     context: api-assume-role-housing-staging-context
-      #     filters:
-      #        branches:
-      #          only: main
-      # - preview-terraform-staging-changes:
-      #     requires:
-      #       - assume-role-staging
-      #     filters:
-      #       branches:
-      #         only: main
-      # - permit-staging-terraform-release:
-      #     type: approval
-      #     requires:
-      #       - preview-terraform-staging-changes
-      #     filters:
-      #       branches:
-      #         only: main
-      # - terraform-init-and-apply-to-staging:
-      #     requires:
-      #       - permit-staging-terraform-release
-      #     filters:
-      #       branches:
-      #         only: main
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+             branches:
+               only: main
+      - preview-terraform-staging-changes:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: main
+      - permit-staging-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-staging-changes
+          filters:
+            branches:
+              only: main
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - permit-staging-terraform-release
+          filters:
+            branches:
+              only: main
       - start-production-release:
           # This approval is needed to make assume role prod trigger
           # when we actually need it, otherwise the temp creds will expire
           type: approval
-          # requires:
-          #   - terraform-init-and-apply-to-staging
+          requires:
+            - terraform-init-and-apply-to-staging
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,27 @@ jobs:
   preview-terraform-production-changes:
     executor: docker-terraform
     steps:
-      - terraform-init-then-plan:
-          environment: "production"
+      - *attach_workspace
+      - checkout
+      - run:
+          name: get and init
+          command: |
+            cd ./production/
+            terraform get -update=true
+            terraform init
+      - run:
+          # TODO: Remove after state is fixed
+          name: fix postgres state drift
+          command: |
+            cd ./production/
+            terraform state rm module.postgres_db_production.aws_db_instance.lbh-db || true
+            terraform import module.postgres_db_production.aws_db_instance.lbh-db mtfh-finance-pgdb-db-production
+      - run:
+          # PLEASE LEAVE THIS AS A PLAN, IF YOU WANT TO CHANGE IT THEN SPEAK TO HUMAIRAA FIRST.
+          name: plan
+          command: |
+            cd ./production/
+            terraform plan
   # Infrastructure deployment:
   terraform-init-and-apply-to-development:
     executor: docker-terraform
@@ -168,36 +187,36 @@ workflows:
             - permit-development-terraform-release
   terraform-apply-staging-and-production:
     jobs:
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          filters:
-             branches:
-               only: main
-      - preview-terraform-staging-changes:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: main
-      - permit-staging-terraform-release:
-          type: approval
-          requires:
-            - preview-terraform-staging-changes
-          filters:
-            branches:
-              only: main
-      - terraform-init-and-apply-to-staging:
-          requires:
-            - permit-staging-terraform-release
-          filters:
-            branches:
-              only: main
+      # - assume-role-staging:
+      #     context: api-assume-role-housing-staging-context
+      #     filters:
+      #        branches:
+      #          only: main
+      # - preview-terraform-staging-changes:
+      #     requires:
+      #       - assume-role-staging
+      #     filters:
+      #       branches:
+      #         only: main
+      # - permit-staging-terraform-release:
+      #     type: approval
+      #     requires:
+      #       - preview-terraform-staging-changes
+      #     filters:
+      #       branches:
+      #         only: main
+      # - terraform-init-and-apply-to-staging:
+      #     requires:
+      #       - permit-staging-terraform-release
+      #     filters:
+      #       branches:
+      #         only: main
       - start-production-release:
           # This approval is needed to make assume role prod trigger
           # when we actually need it, otherwise the temp creds will expire
           type: approval
-          requires:
-            - terraform-init-and-apply-to-staging
+          # requires:
+          #   - terraform-init-and-apply-to-staging
           filters:
             branches:
               only: main

--- a/development/main.tf
+++ b/development/main.tf
@@ -5,7 +5,6 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
     service_name = "mtfh-finance"
-    parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 

--- a/development/postgresdb.tf
+++ b/development/postgresdb.tf
@@ -6,7 +6,7 @@ module "postgres_db_development" {
   environment_name = "development"
   vpc_id =  "vpc-0d15f152935c8716f"
   db_engine = "postgres"
-  db_engine_version = "16.8"
+  db_engine_version = "16.13"
   db_parameter_group_name = "postgres16"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.micro"

--- a/pre-production/postgresdb.tf
+++ b/pre-production/postgresdb.tf
@@ -10,7 +10,7 @@ module "postgres_db_pre_production" {
   environment_name                = var.environment_name
   vpc_id                          = "vpc-062a957b99c8b12e6"
   db_engine                       = "postgres"
-  db_engine_version               = "16.8"
+  db_engine_version               = "16.13"
   db_parameter_group_name         = "default.postgres16"
   db_identifier                   = "mtfh-finance-pgdb"
   db_instance_class               = "db.t3.micro"

--- a/production/main.tf
+++ b/production/main.tf
@@ -5,7 +5,6 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
     service_name = "mtfh-finance"
-    parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 

--- a/production/mysqldb.tf
+++ b/production/mysqldb.tf
@@ -10,7 +10,7 @@ resource "aws_db_subnet_group" "db_subnets" {
 resource "aws_db_instance" "housing-mysql-db" {
   identifier                  = "housing-finance-db-${var.environment_name}"
   engine                      = "mysql"
-  engine_version              = "8.0"
+  engine_version              = "8.0.44"
   instance_class              = "db.t3.medium"
   allocated_storage           = 50
   storage_type                = "gp2"

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -6,7 +6,7 @@ module "postgres_db_production" {
   environment_name = "production"
   vpc_id =  "vpc-0ce853ddb64e8fb3c"
   db_engine = "postgres"
-  db_engine_version = "16.8"
+  db_engine_version = "16.13"
   db_parameter_group_name = "postgres16"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.large"

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -5,7 +5,6 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 locals {
     service_name = "mtfh-finance"
-    parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 

--- a/staging/postgresdb.tf
+++ b/staging/postgresdb.tf
@@ -6,7 +6,7 @@ module "postgres_db_staging" {
   environment_name = "staging"
   vpc_id =  "vpc-064521a7a4109ba31"
   db_engine = "postgres"
-  db_engine_version = "16.8"
+  db_engine_version = "16.13"
   db_parameter_group_name = "postgres16"
   db_identifier = "mtfh-finance-pgdb"
   db_instance_class = "db.t3.micro"


### PR DESCRIPTION
Fix the terraform drift for production.

In 6ac4902 the initial conflicts were fixed, and this PR should help to solidify that and clear the pipeline.