### PR TITLE
Override production DB subnet group in Postgres module

### DIFF
--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "lbh-db" {
   username                    = var.db_username
   password                    = var.db_password
   vpc_security_group_ids      = var.vpc_security_group_ids
-  db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
+  db_subnet_group_name        = var.existing_db_subnet_group_name != null ? var.existing_db_subnet_group_name : aws_db_subnet_group.db_subnets.name
   db_name                     = var.db_name
   monitoring_interval         = 0 //this is for enhanced Monitoring there will allready be some basic monitering avalable
   backup_retention_period     = 30
@@ -41,9 +41,10 @@ resource "aws_db_instance" "lbh-db" {
 
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
 
-  apply_immediately   = false
-  skip_final_snapshot = true
-  publicly_accessible = var.publicly_accessible
+  apply_immediately     = false
+  skip_final_snapshot   = true
+  publicly_accessible   = var.publicly_accessible
+  copy_tags_to_snapshot = true
 
   tags = merge(
     var.additional_tags,

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -75,3 +75,9 @@ variable "additional_tags" {
   type        = map(any)
   default     = {}
 }
+
+variable "existing_db_subnet_group_name" {
+  description = "Name of a pre-existing DB subnet group to attach the instance to."
+  type        = string
+  default     = null
+}

--- a/production/postgresdb.tf
+++ b/production/postgresdb.tf
@@ -15,6 +15,7 @@ module "postgres_db_production" {
   db_username = data.aws_ssm_parameter.housing_finance_postgres_username.value
   db_password = data.aws_ssm_parameter.housing_finance_postgres_password.value
   subnet_ids = ["subnet-0beb266003a56ca82","subnet-06a697d86a9b6ed01"]
+  existing_db_subnet_group_name = "housing-finance-db-subnet-production"
   db_allocated_storage = 100
   maintenance_window ="sun:10:00-sun:10:30"
   backup_window = "00:01-00:31"


### PR DESCRIPTION
It doesn't look like we'll be able to align the terraform with prod, or align prod with the terraform because AWS does not allow you to switch subnet group for a database within the same VPC.

This issue was originally caused by selecting the mysql db subnet group `housing-finance-db-subnet-production` instead of the postgres subnet group `financedbproduction-db-subnet-production` when restoring the snapshot, but they have the exact same config in the same VPC.

As a workaround, this PR adds an `existing_db_subnet_group_name` parameter to the postgres module, to make it not try to change the subnet group in prod and stop giving us the error.

> Error: updating RDS DB Instance (mtfh-finance-pgdb-db-production): operation error RDS: ModifyDBInstance, https response error StatusCode: 400, RequestID: d4adcf9c-3990-4e01-b10e-a5c58a7805b3, api error InvalidParameterCombination: You cannot move a DB instance with Multi-Az enabled to a VPC