### PR TITLE
Flag for enabling/disabling the charges automated schedule

### DIFF
--- a/aws_ecs_fargate_task_module/01-inputs-required.tf
+++ b/aws_ecs_fargate_task_module/01-inputs-required.tf
@@ -31,6 +31,7 @@ variable "tasks" {
     cloudwatch_rule_event_pattern       = string
     task_cpu                            = number
     task_memory                         = number
+    is_enabled                          = optional(bool, true)
     environment_variables = list(object({
       name  = string
       value = string

--- a/aws_ecs_fargate_task_module/20-cloudwatch-event.tf
+++ b/aws_ecs_fargate_task_module/20-cloudwatch-event.tf
@@ -24,6 +24,7 @@ resource "aws_cloudwatch_event_rule" "ecs_task" {
 
   name                = "${each.value.task_id}-cw-event-rule"
   description         = "Runs Fargate scheduled task ${each.value.task_id}"
+  state               = each.value.is_enabled ? "ENABLED" : "DISABLED"
   schedule_expression = each.value.cloudwatch_rule_schedule_expression == null ? null : each.value.cloudwatch_rule_schedule_expression
   event_pattern       = each.value.cloudwatch_rule_event_pattern == null ? null : each.value.cloudwatch_rule_event_pattern
 }

--- a/hfs-nightly-charges/development/main.tf
+++ b/hfs-nightly-charges/development/main.tf
@@ -106,6 +106,7 @@ module "hfs-nightly-charges" {
 
       cloudwatch_rule_schedule_expression = var.charges_cron_expression
       cloudwatch_rule_event_pattern       = null
+      is_enabled                          = var.charges_schedule_enabled
     }
   ]
 

--- a/hfs-nightly-charges/development/variables.tf
+++ b/hfs-nightly-charges/development/variables.tf
@@ -26,3 +26,8 @@ variable "charges_cron_expression" {
   type    = string
   default = "cron(30 0 * * ? *)"
 }
+
+variable "charges_schedule_enabled" {
+  type    = bool
+  default = true
+}

--- a/hfs-nightly-charges/production/main.tf
+++ b/hfs-nightly-charges/production/main.tf
@@ -106,6 +106,7 @@ module "hfs-nightly-charges" {
 
       cloudwatch_rule_schedule_expression = var.charges_cron_expression
       cloudwatch_rule_event_pattern       = null
+      is_enabled                          = var.charges_schedule_enabled
     }
   ]
 

--- a/hfs-nightly-charges/production/variables.tf
+++ b/hfs-nightly-charges/production/variables.tf
@@ -26,3 +26,7 @@ variable "charges_cron_expression" {
   type    = string
   default = "cron(30 0 * * ? *)"
 }
+variable "charges_schedule_enabled" {
+  type    = bool
+  default = true
+}

--- a/hfs-nightly-charges/staging/main.tf
+++ b/hfs-nightly-charges/staging/main.tf
@@ -106,6 +106,7 @@ module "hfs-nightly-charges" {
 
       cloudwatch_rule_schedule_expression = var.charges_cron_expression
       cloudwatch_rule_event_pattern       = null
+      is_enabled                          = var.charges_schedule_enabled
     }
   ]
 

--- a/hfs-nightly-charges/staging/variables.tf
+++ b/hfs-nightly-charges/staging/variables.tf
@@ -26,3 +26,8 @@ variable "charges_cron_expression" {
   type    = string
   default = "cron(30 0 * * ? *)"
 }
+
+variable "charges_schedule_enabled" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
Need this flag to reduce risk from releasing the finance process orchestrator.

In case of failure we can revert by simply fliping these enabled flags.

For now left them true - so the current automated process will continue as before.