### PR TITLE
Update terraform to avoid diffs

### DIFF
--- a/hfs-nightly-charges/development/main.tf
+++ b/hfs-nightly-charges/development/main.tf
@@ -66,7 +66,7 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     from_port        = 1433
     to_port          = 1433
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    cidr_blocks      = []
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -75,6 +75,10 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    OpenIngressRemoved = "True"
   }
 }
 

--- a/hfs-nightly-charges/production/main.tf
+++ b/hfs-nightly-charges/production/main.tf
@@ -66,7 +66,7 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     from_port        = 1433
     to_port          = 1433
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    cidr_blocks      = []
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -75,6 +75,10 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    OpenIngressRemoved = "True"
   }
 }
 

--- a/hfs-nightly-charges/staging/main.tf
+++ b/hfs-nightly-charges/staging/main.tf
@@ -66,7 +66,7 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     from_port        = 1433
     to_port          = 1433
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
+    cidr_blocks      = []
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -75,6 +75,10 @@ resource "aws_security_group" "hfs_nightly_jobs" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    OpenIngressRemoved = "True"
   }
 }
 


### PR DESCRIPTION
AWS is auto-removing our cidr_blocks and adding  OpenIngressRemoved - presumably this is a security policy because it shouldn't be fully open like this.

To avoid diffs in the terraform, this matches the terraform with the infrastructure