### PR TITLE
Enable prod charges schedule (temp)

### DIFF
--- a/hfs-nightly-charges/production/variables.tf
+++ b/hfs-nightly-charges/production/variables.tf
@@ -28,5 +28,5 @@ variable "charges_cron_expression" {
 }
 variable "charges_schedule_enabled" {
   type    = bool
-  default = false
+  default = true
 }


### PR DESCRIPTION
We won't have many people available tomorrow in case something goes wrong with the overnight run tonight - disable prod for now with aim to release tomorrow and resolve issues on Friday